### PR TITLE
[IC-51] feat: Redis pub/sub를 이용한 파일업로드 메시지 전송 및 DB 저장

### DIFF
--- a/file/src/main/java/com/initcloud/rocket23/common/enums/ResponseCode.java
+++ b/file/src/main/java/com/initcloud/rocket23/common/enums/ResponseCode.java
@@ -23,7 +23,8 @@ public enum ResponseCode {
 	AWS_FILE_UPLOAD_ERROR(5204, HttpStatus.INTERNAL_SERVER_ERROR, "AWS 파일 업로드 오류입니다."),
 	FILE_WRONG_ERROR(5205,HttpStatus.INTERNAL_SERVER_ERROR,"파일이 올바르지 않습니다."),
 	ZIP_PATH_ERROR(5206,HttpStatus.INTERNAL_SERVER_ERROR,"zip 파일 경로가 올바르지 않습니다."),
-	ZIP_ENCODING_ERROR(5207,HttpStatus.INTERNAL_SERVER_ERROR,"압축파일 인코딩 오류입니다.");
+	ZIP_ENCODING_ERROR(5207,HttpStatus.INTERNAL_SERVER_ERROR,"압축파일 인코딩 오류입니다."),
+	JSON_PROCESSING_ERROR(5208,HttpStatus.INTERNAL_SERVER_ERROR,"Redis Publish JSON 직렬화 오류입니다.");
 
 	private final int code;
 	private final HttpStatus httpStatus;

--- a/file/src/main/java/com/initcloud/rocket23/file/dto/FileDto.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/dto/FileDto.java
@@ -1,6 +1,7 @@
 package com.initcloud.rocket23.file.dto;
 
 import com.initcloud.rocket23.file.entity.FileEntity;
+import com.initcloud.rocket23.file.enums.ServerType;
 
 import lombok.*;
 
@@ -11,10 +12,10 @@ public class FileDto {
 	private String fileName;
 	private String uuid;
 	private String path;
-	private String serverType;
+	private ServerType serverType;
 
 	@Builder
-	public FileDto(Long id, String fileName, String uuid, String path, String serverType) {
+	public FileDto(Long id, String fileName, String uuid, String path, ServerType serverType) {
 		this.id = id;
 		this.fileName = fileName;
 		this.uuid = uuid;
@@ -22,7 +23,7 @@ public class FileDto {
 		this.serverType = serverType;
 	}
 
-	public static FileDto toDto(String name, String uuid, String path, String serverType) {
+	public static FileDto toDto(String name, String uuid, String path, ServerType serverType) {
 		return FileDto.builder()
 			.fileName(name)
 			.uuid(uuid)

--- a/file/src/main/java/com/initcloud/rocket23/file/dto/RedisFileDto.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/dto/RedisFileDto.java
@@ -1,0 +1,23 @@
+package com.initcloud.rocket23.file.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RedisFileDto {
+	private String uuid;
+
+	@Builder
+	public RedisFileDto(String uuid){
+		this.uuid = uuid;
+	}
+
+	public static RedisFileDto toDto(String uuid){
+		return RedisFileDto.builder()
+			.uuid(uuid)
+			.build();
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/file/dto/RedisFileDto.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/dto/RedisFileDto.java
@@ -1,5 +1,9 @@
 package com.initcloud.rocket23.file.dto;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,15 +13,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RedisFileDto {
 	private String uuid;
+	private LocalDateTime createdAt;
 
 	@Builder
-	public RedisFileDto(String uuid){
+	public RedisFileDto(String uuid, LocalDateTime createdAt) {
 		this.uuid = uuid;
+		this.createdAt = createdAt;
 	}
 
-	public static RedisFileDto toDto(String uuid){
+	public static RedisFileDto toDto(String uuid) {
 		return RedisFileDto.builder()
 			.uuid(uuid)
+			.createdAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/file/src/main/java/com/initcloud/rocket23/file/entity/FileEntity.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/entity/FileEntity.java
@@ -46,4 +46,11 @@ public class FileEntity extends BaseEntity {
 		this.path = path;
 		this.serverType = serverType;
 	}
+
+	public FileEntity(String fileName, String uuid, String path, ServerType serverType) {
+		this.fileName = fileName;
+		this.uuid = uuid;
+		this.path = path;
+		this.serverType = serverType;
+	}
 }

--- a/file/src/main/java/com/initcloud/rocket23/file/entity/FileEntity.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/entity/FileEntity.java
@@ -1,6 +1,7 @@
 package com.initcloud.rocket23.file.entity;
 
 import com.initcloud.rocket23.common.entity.BaseEntity;
+import com.initcloud.rocket23.file.enums.ServerType;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,10 +35,11 @@ public class FileEntity extends BaseEntity {
 	private String path;
 
 	@Column(name = "SERVER_TYPE")
-	private String serverType;
+	@Enumerated(EnumType.STRING)
+	private ServerType serverType;
 
 	@Builder
-	public FileEntity(Long id, String fileName, String uuid, String path, String serverType) {
+	public FileEntity(Long id, String fileName, String uuid, String path, ServerType serverType) {
 		this.id = id;
 		this.fileName = fileName;
 		this.uuid = uuid;

--- a/file/src/main/java/com/initcloud/rocket23/file/enums/ServerType.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/enums/ServerType.java
@@ -1,0 +1,10 @@
+package com.initcloud.rocket23.file.enums;
+
+/**
+ * Server type에 대한 enum 클래스
+ * todo 추가적으로 서버타입에 대한 규정을 해야함, 우선은 s3와 local 두가지로 표현함.
+ */
+public enum ServerType {
+	LOCAL,
+	S3
+}

--- a/file/src/main/java/com/initcloud/rocket23/file/service/FileService.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/service/FileService.java
@@ -5,6 +5,8 @@ import java.nio.file.Path;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.initcloud.rocket23.file.enums.ServerType;
+
 public interface FileService {
 	void init(Path path);
 
@@ -16,5 +18,5 @@ public interface FileService {
 	void unZip(MultipartFile file, Path path) throws IOException, IllegalArgumentException;
 
 	//DB 저장
-	void save(MultipartFile file, String type, String uploadPath);
+	void save(MultipartFile file, ServerType type, String uploadPath);
 }

--- a/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
@@ -35,6 +35,8 @@ public class FileServiceImpl implements FileService {
 	private final FileRepository fileRepository;
 	private final RedisMessagePublisher redisMessagePublisher;
 
+	private String check = "zip";
+	private Charset CP866 = Charset.forName("CP866");
 	@Value("${spring.servlet.multipart.location}")
 	private String uploadPath;
 
@@ -107,7 +109,7 @@ public class FileServiceImpl implements FileService {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param file 업로드된 파일
 	 * @param type 파일 저장 종류
 	 * @param uploadPath 파일이 저장된 root 디렉토리 위치
@@ -118,8 +120,7 @@ public class FileServiceImpl implements FileService {
 	public void save(MultipartFile file, ServerType type, String uploadPath) {
 		String name = file.getOriginalFilename();
 		String uuid = UUID.randomUUID().toString();
-		FileEntity fileEntity = FileDto.toDto(name, uuid, uploadPath, type).toEntity();
-		fileRepository.save(fileEntity);
+		fileRepository.save(new FileEntity(name, uuid, uploadPath, type));
 		redisMessagePublisher.publishFileMessage(RedisFileDto.toDto(uuid));
 	}
 
@@ -133,7 +134,6 @@ public class FileServiceImpl implements FileService {
 	private boolean isZip(MultipartFile file) {
 		String fileName = file.getOriginalFilename();
 		String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-		String check = "zip";
 		/*
 		TODO: 2023-06-20 zip확장자뿐만이 아니라 tar.gz과 같은 다른 확장자 고려
 		 */
@@ -153,7 +153,6 @@ public class FileServiceImpl implements FileService {
 	 */
 	@Override
 	public void unZip(MultipartFile file, Path path) throws IOException, IllegalArgumentException {
-		Charset CP866 = Charset.forName("CP866");
 		try (ZipInputStream zipInputStream = new ZipInputStream(file.getInputStream(), CP866)) {
 			ZipEntry zipEntry = zipInputStream.getNextEntry();
 			while (zipEntry != null) {

--- a/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
@@ -3,10 +3,12 @@ package com.initcloud.rocket23.file.service.Impl;
 import com.initcloud.rocket23.common.enums.ResponseCode;
 import com.initcloud.rocket23.common.exception.ApiException;
 import com.initcloud.rocket23.file.dto.FileDto;
+import com.initcloud.rocket23.file.dto.RedisFileDto;
 import com.initcloud.rocket23.file.entity.FileEntity;
 import com.initcloud.rocket23.file.enums.ServerType;
 import com.initcloud.rocket23.file.repository.FileRepository;
 import com.initcloud.rocket23.file.service.FileService;
+import com.initcloud.rocket23.redis.pubsub.RedisMessagePublisher;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,7 +31,9 @@ import java.util.zip.ZipInputStream;
 @RequiredArgsConstructor
 @Service
 public class FileServiceImpl implements FileService {
+
 	private final FileRepository fileRepository;
+	private final RedisMessagePublisher redisMessagePublisher;
 
 	@Value("${spring.servlet.multipart.location}")
 	private String uploadPath;
@@ -100,6 +104,7 @@ public class FileServiceImpl implements FileService {
 			}
 		}
 		save(file, ServerType.LOCAL, path.toString());
+		redisMessagePublisher.publishScanMessage(RedisFileDto.toDto("1"));
 	}
 
 	@Override

--- a/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
@@ -4,6 +4,7 @@ import com.initcloud.rocket23.common.enums.ResponseCode;
 import com.initcloud.rocket23.common.exception.ApiException;
 import com.initcloud.rocket23.file.dto.FileDto;
 import com.initcloud.rocket23.file.entity.FileEntity;
+import com.initcloud.rocket23.file.enums.ServerType;
 import com.initcloud.rocket23.file.repository.FileRepository;
 import com.initcloud.rocket23.file.service.FileService;
 
@@ -98,11 +99,11 @@ public class FileServiceImpl implements FileService {
 					StandardCopyOption.REPLACE_EXISTING);
 			}
 		}
-		save(file, "local", path.toString());
+		save(file, ServerType.LOCAL, path.toString());
 	}
 
 	@Override
-	public void save(MultipartFile file, String type, String uploadPath) {
+	public void save(MultipartFile file, ServerType type, String uploadPath) {
 		String name = file.getOriginalFilename();
 		String uuid = UUID.randomUUID().toString();
 		FileEntity fileEntity = FileDto.toDto(name, uuid, uploadPath, type).toEntity();
@@ -175,4 +176,5 @@ public class FileServiceImpl implements FileService {
 		}
 		return normalizePath;
 	}
+
 }

--- a/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
+++ b/file/src/main/java/com/initcloud/rocket23/file/service/Impl/FileServiceImpl.java
@@ -104,15 +104,23 @@ public class FileServiceImpl implements FileService {
 			}
 		}
 		save(file, ServerType.LOCAL, path.toString());
-		redisMessagePublisher.publishScanMessage(RedisFileDto.toDto("1"));
 	}
 
+	/**
+	 * 
+	 * @param file 업로드된 파일
+	 * @param type 파일 저장 종류
+	 * @param uploadPath 파일이 저장된 root 디렉토리 위치
+	 * 파일 정보를 repository에 저장
+	 * 저장 후 redis publish를 통한 uuid, timestamp 정보 메세지 생성   
+	 */
 	@Override
 	public void save(MultipartFile file, ServerType type, String uploadPath) {
 		String name = file.getOriginalFilename();
 		String uuid = UUID.randomUUID().toString();
 		FileEntity fileEntity = FileDto.toDto(name, uuid, uploadPath, type).toEntity();
 		fileRepository.save(fileEntity);
+		redisMessagePublisher.publishFileMessage(RedisFileDto.toDto(uuid));
 	}
 
 	/**

--- a/file/src/main/java/com/initcloud/rocket23/redis/config/RedisClientConfig.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/config/RedisClientConfig.java
@@ -1,0 +1,21 @@
+package com.initcloud.rocket23.redis.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.codec.JsonJacksonCodec;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisClientConfig {
+	// Todo - setAddress -> 환경 변수로 옮길 예정
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.setCodec(new JsonJacksonCodec())
+			.useSingleServer()
+			.setAddress("redis://127.0.0.1:6379");
+		return Redisson.create(config);
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/redis/config/RedisPubSubConfig.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/config/RedisPubSubConfig.java
@@ -16,14 +16,8 @@ public class RedisPubSubConfig {
 	private final RedissonClient redissonClient;
 
 	@Bean
-	public RTopic topicScan() {
-		RTopic topic = redissonClient.getTopic(Channels.SCAN.getChannel());
-		return topic;
-	}
-
-	@Bean
-	public RTopic topicContainer() {
-		RTopic topic = redissonClient.getTopic(Channels.CONTAINER.getChannel());
+	public RTopic topicFile() {
+		RTopic topic = redissonClient.getTopic(Channels.FILE.getChannel());
 		return topic;
 	}
 }

--- a/file/src/main/java/com/initcloud/rocket23/redis/config/RedisPubSubConfig.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/config/RedisPubSubConfig.java
@@ -1,0 +1,29 @@
+package com.initcloud.rocket23.redis.config;
+
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.initcloud.rocket23.redis.enums.Channels;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisPubSubConfig {
+
+	private final RedissonClient redissonClient;
+
+	@Bean
+	public RTopic topicScan() {
+		RTopic topic = redissonClient.getTopic(Channels.SCAN.getChannel());
+		return topic;
+	}
+
+	@Bean
+	public RTopic topicContainer() {
+		RTopic topic = redissonClient.getTopic(Channels.CONTAINER.getChannel());
+		return topic;
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/redis/enums/Channels.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/enums/Channels.java
@@ -7,8 +7,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Channels {
 
-	CONTAINER("channel.container"),
-	SCAN("channel.scan");
+	FILE("channel.file");
 
 	@Getter
 	private String channel;

--- a/file/src/main/java/com/initcloud/rocket23/redis/enums/Channels.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/enums/Channels.java
@@ -1,0 +1,19 @@
+package com.initcloud.rocket23.redis.enums;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Channels {
+
+	CONTAINER("channel.container"),
+	SCAN("channel.scan");
+
+	@Getter
+	private String channel;
+
+	Channels(String channel) {
+		this.channel = channel;
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
@@ -4,6 +4,12 @@ import org.redisson.api.RTopic;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiException;
+import com.initcloud.rocket23.file.dto.RedisFileDto;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,11 +24,17 @@ public class RedisMessagePublisher {
 	@Qualifier("topicContainer")
 	private final RTopic topicContainer;
 
+	private final ObjectMapper objectMapper;
 	public void publishContainerMessage(String data) {
 		topicContainer.publish(data);
 	}
 
-	public void publishScanMessage(String data) {
-		topicScan.publish(data);
+	public void publishScanMessage(RedisFileDto data) {
+		try{
+			String jsonMessage = objectMapper.writeValueAsString(data);
+			topicScan.publish(jsonMessage);
+		} catch (JsonProcessingException e) {
+			throw new ApiException(ResponseCode.JSON_PROCESSING_ERROR);
+		}
 	}
 }

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
@@ -24,7 +24,7 @@ public class RedisMessagePublisher {
 	private final ObjectMapper objectMapper;
 
 	public void publishFileMessage(RedisFileDto data) {
-		try{
+		try {
 			String jsonMessage = objectMapper.writeValueAsString(data);
 			topicFile.publish(jsonMessage);
 		} catch (JsonProcessingException e) {

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
@@ -18,21 +18,15 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RedisMessagePublisher {
 
-	@Qualifier("topicScan")
-	private final RTopic topicScan;
-
-	@Qualifier("topicContainer")
-	private final RTopic topicContainer;
+	@Qualifier("topicFile")
+	private final RTopic topicFile;
 
 	private final ObjectMapper objectMapper;
-	public void publishContainerMessage(String data) {
-		topicContainer.publish(data);
-	}
 
-	public void publishScanMessage(RedisFileDto data) {
+	public void publishFileMessage(RedisFileDto data) {
 		try{
 			String jsonMessage = objectMapper.writeValueAsString(data);
-			topicScan.publish(jsonMessage);
+			topicFile.publish(jsonMessage);
 		} catch (JsonProcessingException e) {
 			throw new ApiException(ResponseCode.JSON_PROCESSING_ERROR);
 		}

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessagePublisher.java
@@ -1,0 +1,28 @@
+package com.initcloud.rocket23.redis.pubsub;
+
+import org.redisson.api.RTopic;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisMessagePublisher {
+
+	@Qualifier("topicScan")
+	private final RTopic topicScan;
+
+	@Qualifier("topicContainer")
+	private final RTopic topicContainer;
+
+	public void publishContainerMessage(String data) {
+		topicContainer.publish(data);
+	}
+
+	public void publishScanMessage(String data) {
+		topicScan.publish(data);
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessageSubscriber.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessageSubscriber.java
@@ -15,20 +15,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RedisMessageSubscriber {
 
-	@Qualifier("topicScan")
-	private final RTopic topicScan;
-
-	@Qualifier("topicContainer")
-	private final RTopic topicContainer;
+	@Qualifier("topicFile")
+	private final RTopic topicFile;
 
 	@PostConstruct
 	public void initialize() {
-		subscribeScanChannel();
+		subscribeFileChannel();
 	}
 
-	public void subscribeScanChannel() {
-		log.info("[Subscribe Scan Channel]");
-		topicScan.addListener(String.class, (channel, data) -> {
+	public void subscribeFileChannel() {
+		log.info("[Subscribe File Channel]");
+		topicFile.addListener(String.class, (channel, data) -> {
 			try {
 				log.info("[RECEIVED] {} - {}", channel, data);
 			} catch (DecoderException e) {

--- a/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessageSubscriber.java
+++ b/file/src/main/java/com/initcloud/rocket23/redis/pubsub/RedisMessageSubscriber.java
@@ -1,0 +1,41 @@
+package com.initcloud.rocket23.redis.pubsub;
+
+import javax.annotation.PostConstruct;
+
+import org.redisson.api.RTopic;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import io.netty.handler.codec.DecoderException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisMessageSubscriber {
+
+	@Qualifier("topicScan")
+	private final RTopic topicScan;
+
+	@Qualifier("topicContainer")
+	private final RTopic topicContainer;
+
+	@PostConstruct
+	public void initialize() {
+		subscribeScanChannel();
+	}
+
+	public void subscribeScanChannel() {
+		log.info("[Subscribe Scan Channel]");
+		topicScan.addListener(String.class, (channel, data) -> {
+			try {
+				log.info("[RECEIVED] {} - {}", channel, data);
+			} catch (DecoderException e) {
+				log.warn("[DECODE ERROR] - from {}, about {}", channel, e.getMessage());
+			} catch (Exception e) {
+				log.warn("[DATA BIND ERROR] - from {}, about {}", channel, e.getMessage());
+			}
+		});
+	}
+}

--- a/file/src/main/java/com/initcloud/rocket23/s3/service/Impl/S3ServiceImpl.java
+++ b/file/src/main/java/com/initcloud/rocket23/s3/service/Impl/S3ServiceImpl.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.initcloud.rocket23.common.enums.ResponseCode;
 import com.initcloud.rocket23.common.exception.ApiException;
 import com.initcloud.rocket23.file.dto.FileDto;
+import com.initcloud.rocket23.file.enums.ServerType;
 import com.initcloud.rocket23.file.repository.FileRepository;
 import com.initcloud.rocket23.s3.service.S3Service;
 
@@ -23,6 +24,11 @@ public class S3ServiceImpl implements S3Service {
 	private final AmazonS3Client amazonS3Client;
 	private final FileRepository fileRepository;
 
+	/**
+	 *
+	 * @param file 업로드된 파일
+	 *  S3에 저장
+	 */
 	@Override
 	public void store(MultipartFile file) {
 		checkEmptyFile(file);
@@ -32,7 +38,7 @@ public class S3ServiceImpl implements S3Service {
 			String uuid = UUID.randomUUID().toString();
 			String filePath = "https://" + bucket + "/" + fileName;
 			storeFileToAmazonS3(file, bucket, fileName);
-			fileRepository.save(FileDto.toDto(fileName, uuid, filePath, bucket).toEntity());
+			fileRepository.save(FileDto.toDto(fileName, uuid, filePath, ServerType.S3).toEntity());
 		} catch (IOException e) {
 			throw new ApiException(ResponseCode.AWS_FILE_UPLOAD_ERROR);
 		} catch (Exception e) {

--- a/file/src/main/resources/application.yaml
+++ b/file/src/main/resources/application.yaml
@@ -17,6 +17,9 @@ spring:
     show-sql: true
   profiles:
     active: dev, db-maria
+  redis:
+    host: ${REDIS_DATASOURCE_URL}
+    port: ${REDIS_PORT}
 cloud:
   aws:
     stack:


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #27

## Update Summary
- Redis pub/sub 구현
- 파일업로드 DB 저장
- 파일업로드 정보 publish를 통한 메세지 생성
- redis에 전송할 파일업로드 정보 dto 구현

## New/Edited policies
- DB에 기록되는 ServerType에 대한 Enum으로 처리
- Redis channel `channel.file` 생성 및 channel에 대한 `publisher` , `subscriber` 구현
- `publisher`를 사용해 파일업로드 시 DB 저장 이후 업로드 정보 메세지를 channel로 전송
- 업로드 정보를 Dto로 구현해서, 추가정보에 대한 수정을 편의하게함

## Resolved Issue
publish할 때 Json 직렬화 문제를 Jackson라이브러리를 사용해서 해결

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [x] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.