### PR TITLE
[IC-54] feat: User에 대한 인가 구현

### DIFF
--- a/scanhistory/src/main/java/com/initcloud/rocket23/ScanHistoryApplication.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/ScanHistoryApplication.java
@@ -1,0 +1,14 @@
+package com.initcloud.rocket23;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@EnableFeignClients(basePackages = {"com.initcloud.rocket23.common.feign"})
+@SpringBootApplication
+public class ScanHistoryApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ScanHistoryApplication.class, args);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/config/WebConfig.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.initcloud.rocket23.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("*")
+			.allowedHeaders("*")
+			.allowedMethods("GET", "POST", "PUT", "DELETE");
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/dto/ExceptionDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/dto/ExceptionDto.java
@@ -1,0 +1,20 @@
+package com.initcloud.rocket23.common.dto;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ExceptionDto {
+	private final int code;
+	private final String message;
+
+	@Builder
+	public ExceptionDto(ResponseCode res) {
+		this.code = res.getCode();
+		this.message = res.getMessage();
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/dto/ResponseDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/dto/ResponseDto.java
@@ -1,0 +1,56 @@
+package com.initcloud.rocket23.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiAuthException;
+import com.initcloud.rocket23.common.exception.ApiException;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class ResponseDto<T> {
+	private final Boolean success;
+	private final T data;
+	private final ExceptionDto error;
+
+	public ResponseDto(@Nullable T data) {
+		this.success = true;
+		this.data = data;
+		this.error = null;
+	}
+
+	public static ResponseEntity<Object> toException(ApiException e) {
+		return ResponseEntity.status(e.getResponseCode().getHttpStatus())
+			.body(ResponseDto.builder()
+				.success(false)
+				.data(null)
+				.error(new ExceptionDto(e.getResponseCode()))
+				.build());
+	}
+
+	// JWT, 인가 관련 ExceptionDto
+	public static ResponseEntity<Object> toException(ApiAuthException e) {
+		return ResponseEntity.status(e.getResponseCode().getHttpStatus())
+			.body(ResponseDto.builder()
+				.success(false)
+				.data(null)
+				.error(new ExceptionDto(e.getResponseCode()))
+				.build());
+	}
+
+	public static ResponseEntity<Object> toException(Exception e) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ResponseDto.builder()
+				.success(false)
+				.data(null)
+				.error(new ExceptionDto(ResponseCode.SERVER_ERROR))
+				.build());
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/entity/BaseEntity.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/entity/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.initcloud.rocket23.common.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+	protected BaseEntity(LocalDateTime createdAt, LocalDateTime modifiedAt) {
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/entity/BaseEntity.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/entity/BaseEntity.java
@@ -21,15 +21,10 @@ import lombok.NoArgsConstructor;
 public abstract class BaseEntity {
 
 	@CreatedDate
-	@Column(name = "created_at")
+	@Column(name = "created_at", updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
 	@Column(name = "modified_at")
 	private LocalDateTime modifiedAt;
-
-	protected BaseEntity(LocalDateTime createdAt, LocalDateTime modifiedAt) {
-		this.createdAt = createdAt;
-		this.modifiedAt = modifiedAt;
-	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/enums/ResponseCode.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/enums/ResponseCode.java
@@ -1,0 +1,40 @@
+package com.initcloud.rocket23.common.enums;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ResponseCode {
+
+	/* Invalid Request */
+	INVALID_REQUEST(4001, HttpStatus.BAD_REQUEST, "Invalid Request."),
+	DATA_MISSING(4002, HttpStatus.INTERNAL_SERVER_ERROR, "BAD_REQUEST"),
+	INVALID_TOKEN(4015, HttpStatus.UNAUTHORIZED, "Invalid Token signature."),
+	INVALID_TOKEN_FORMAT(4016, HttpStatus.UNAUTHORIZED, "Invalid Token format."),
+	UNSUPPORTED_TOKEN(4017, HttpStatus.UNAUTHORIZED, "Unsupported Token."),
+	INVALID_TOKEN_SIGNATURE(4018, HttpStatus.UNAUTHORIZED, "Invalid Token signature."),
+	EMPTY_TOKEN_CLAIMS(4019, HttpStatus.UNAUTHORIZED, "Empty Token Claims."),
+	NULL_TOKEN(4020, HttpStatus.UNAUTHORIZED, "Token is null"),
+	INVALID_CREDENTIALS(4021, HttpStatus.UNAUTHORIZED, "Can not access OAuth"),
+	TOKEN_EXPIRED(4022, HttpStatus.UNAUTHORIZED, "Token Expired."),
+
+	/* Server Error. */
+	SERVER_BUSY(5001, HttpStatus.INTERNAL_SERVER_ERROR, "Server busy."),
+	SCAN_ERROR(5002, HttpStatus.INTERNAL_SERVER_ERROR, "Scan Error."),
+	SERVER_ERROR(5100, HttpStatus.INTERNAL_SERVER_ERROR, "Unknown error."),
+	/*File Uplaod Error. */
+	SERVER_CREATED_DIR_ERROR(5201, HttpStatus.INTERNAL_SERVER_ERROR, "디렉토리를 생성할 수 없습니다."),
+	SERVER_STORE_ERROR(5202, HttpStatus.INTERNAL_SERVER_ERROR, "서버 저장 오류입니다."),
+	FILE_EMPTY(5203, HttpStatus.INTERNAL_SERVER_ERROR, "빈 파일입니다."),
+	AWS_FILE_UPLOAD_ERROR(5204, HttpStatus.INTERNAL_SERVER_ERROR, "AWS 파일 업로드 오류입니다."),
+	FILE_WRONG_ERROR(5205, HttpStatus.INTERNAL_SERVER_ERROR, "파일이 올바르지 않습니다."),
+	ZIP_PATH_ERROR(5206, HttpStatus.INTERNAL_SERVER_ERROR, "zip 파일 경로가 올바르지 않습니다."),
+	ZIP_ENCODING_ERROR(5207, HttpStatus.INTERNAL_SERVER_ERROR, "압축파일 인코딩 오류입니다.");
+
+	private final int code;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/exception/ApiAuthException.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/exception/ApiAuthException.java
@@ -1,0 +1,13 @@
+package com.initcloud.rocket23.common.exception;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiAuthException extends RuntimeException {
+	private final ResponseCode responseCode;
+}
+

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/exception/ApiException.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/exception/ApiException.java
@@ -1,0 +1,16 @@
+package com.initcloud.rocket23.common.exception;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Getter
+public class ApiException extends RuntimeException {
+
+	private Throwable ex;
+	private final ResponseCode responseCode;
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/feign/OAuthFeignClient.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/feign/OAuthFeignClient.java
@@ -1,0 +1,14 @@
+package com.initcloud.rocket23.common.feign;
+
+import com.initcloud.rocket23.security.dto.OAuthDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@FeignClient(name = "feignClient", contextId = "oauthFeignClient", url = "https://github.com")
+public interface OAuthFeignClient {
+
+    @PostMapping(value = "/login/oauth/access_token")
+    String requestGithubAccessToken(@RequestBody OAuthDto.GithubTokenRequest tokenRequest);
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/feign/OAuthInfoFeignClient.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/feign/OAuthInfoFeignClient.java
@@ -1,0 +1,14 @@
+package com.initcloud.rocket23.common.feign;
+
+import com.initcloud.rocket23.security.dto.OAuthDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+
+@FeignClient(name = "feignClient", contextId = "oauthInfoFeignClient", url = "https://api.github.com")
+public interface OAuthInfoFeignClient {
+
+    @GetMapping(value = "/user")
+    OAuthDto.GithubUserDetail requestGithubUserDetail(@RequestHeader("Authorization") String token);
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/common/handler/CommonExceptionHandler.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/common/handler/CommonExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.initcloud.rocket23.common.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+import com.initcloud.rocket23.common.exception.ApiException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestControllerAdvice
+@Slf4j
+public class CommonExceptionHandler {
+
+	@ExceptionHandler(value = ApiException.class)
+	public ResponseEntity<Object> handleApi(ApiException exception) {
+		return ResponseDto.toException(exception);
+	}
+
+	@ExceptionHandler(value = Exception.class)
+	public ResponseEntity<Object> handle(Exception exception) {
+		return ResponseDto.toException(exception);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/FeaturesRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/FeaturesRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.role.entity.Features;
+
+public interface FeaturesRepository extends JpaRepository<Features, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/TeamRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.team.entity.Team;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/TeamWithUsersRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/TeamWithUsersRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.team.entity.TeamWithUsers;
+
+public interface TeamWithUsersRepository extends JpaRepository<TeamWithUsers, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserAuthorityOfRoleRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserAuthorityOfRoleRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.role.entity.UserAuthorityOfRole;
+
+public interface UserAuthorityOfRoleRepository extends JpaRepository<UserAuthorityOfRole, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserAuthorityRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserAuthorityRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.role.entity.UserAuthority;
+
+public interface UserAuthorityRepository extends JpaRepository<UserAuthority, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.initcloud.rocket23.infra.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findUserByUsername(String username);
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRoleOfTeamRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRoleOfTeamRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.role.entity.UserRoleOfTeam;
+
+public interface UserRoleOfTeamRepository extends JpaRepository<UserRoleOfTeam, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRoleRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/UserRoleRepository.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.initcloud.rocket23.role.entity.UserRole;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/controller/RbacController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/controller/RbacController.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.role.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RbacController {
+    //Todo
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/controller/RoleController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/controller/RoleController.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.role.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RoleController {
+    //Todo
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/Features.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/Features.java
@@ -18,22 +18,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Features extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private String featureType;
+    private String featureType;
 
-	private String featureName;
+    private String featureName;
 
-	private String featureUri;
+    private String featureUri;
 
-	public Features(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String featureType,
-		String featureName, String featureUri) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.featureType = featureType;
-		this.featureName = featureName;
-		this.featureUri = featureUri;
-	}
+    public Features(Long id, String featureType, String featureName, String featureUri) {
+        this.id = id;
+        this.featureType = featureType;
+        this.featureName = featureName;
+        this.featureUri = featureUri;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/Features.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/Features.java
@@ -1,0 +1,39 @@
+package com.initcloud.rocket23.role.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Features extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String featureType;
+
+	private String featureName;
+
+	private String featureUri;
+
+	public Features(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String featureType,
+		String featureName, String featureUri) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.featureType = featureType;
+		this.featureName = featureName;
+		this.featureUri = featureUri;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthority.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthority.java
@@ -1,0 +1,39 @@
+package com.initcloud.rocket23.role.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAuthority extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String authorityName;
+
+	private String authorityType;
+
+	private Integer authorityPriority;
+
+	public UserAuthority(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id,
+		String authorityName, String authorityType, Integer authorityPriority) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.authorityName = authorityName;
+		this.authorityType = authorityType;
+		this.authorityPriority = authorityPriority;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthority.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthority.java
@@ -18,22 +18,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserAuthority extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private String authorityName;
+    private String authorityName;
 
-	private String authorityType;
+    private String authorityType;
 
-	private Integer authorityPriority;
+    private Integer authorityPriority;
 
-	public UserAuthority(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id,
-		String authorityName, String authorityType, Integer authorityPriority) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.authorityName = authorityName;
-		this.authorityType = authorityType;
-		this.authorityPriority = authorityPriority;
-	}
+    public UserAuthority(Long id, String authorityName, String authorityType, Integer authorityPriority) {
+        this.id = id;
+        this.authorityName = authorityName;
+        this.authorityType = authorityType;
+        this.authorityPriority = authorityPriority;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthorityOfRole.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthorityOfRole.java
@@ -1,0 +1,49 @@
+package com.initcloud.rocket23.role.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+import com.initcloud.rocket23.team.entity.TeamWithUsers;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAuthorityOfRole extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private TeamWithUsers userWithTeam;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private UserAuthority userAuthority;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Features features;
+
+	public UserAuthorityOfRole(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id,
+		TeamWithUsers userWithTeam, UserAuthority userAuthority, Features features) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.userWithTeam = userWithTeam;
+		this.userAuthority = userAuthority;
+		this.features = features;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthorityOfRole.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserAuthorityOfRole.java
@@ -22,28 +22,26 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserAuthorityOfRole extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private TeamWithUsers userWithTeam;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private TeamWithUsers userWithTeam;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private UserAuthority userAuthority;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private UserAuthority userAuthority;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private Features features;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Features features;
 
-	public UserAuthorityOfRole(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id,
-		TeamWithUsers userWithTeam, UserAuthority userAuthority, Features features) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.userWithTeam = userWithTeam;
-		this.userAuthority = userAuthority;
-		this.features = features;
-	}
+    public UserAuthorityOfRole(Long id, TeamWithUsers userWithTeam, UserAuthority userAuthority, Features features) {
+        this.id = id;
+        this.userWithTeam = userWithTeam;
+        this.userAuthority = userAuthority;
+        this.features = features;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRole.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRole.java
@@ -1,0 +1,35 @@
+package com.initcloud.rocket23.role.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRole extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String roleName;
+
+	private Integer rolePriority;
+
+	public UserRole(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String roleName,
+		Integer rolePriority) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.roleName = roleName;
+		this.rolePriority = rolePriority;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRole.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRole.java
@@ -17,19 +17,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRole extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private String roleName;
+    private String roleName;
 
-	private Integer rolePriority;
+    private Integer rolePriority;
 
-	public UserRole(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String roleName,
-		Integer rolePriority) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.roleName = roleName;
-		this.rolePriority = rolePriority;
-	}
+    public UserRole(Long id, String roleName, Integer rolePriority) {
+        this.id = id;
+        this.roleName = roleName;
+        this.rolePriority = rolePriority;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRoleOfTeam.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRoleOfTeam.java
@@ -1,0 +1,42 @@
+package com.initcloud.rocket23.role.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRoleOfTeam extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private UserRole userRole;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private UserAuthorityOfRole userAuthorityOfRole;
+
+	public UserRoleOfTeam(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, UserRole userRole,
+		UserAuthorityOfRole userAuthorityOfRole) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.userRole = userRole;
+		this.userAuthorityOfRole = userAuthorityOfRole;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRoleOfTeam.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/role/entity/UserRoleOfTeam.java
@@ -20,23 +20,21 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRoleOfTeam extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private UserRole userRole;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private UserRole userRole;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private UserAuthorityOfRole userAuthorityOfRole;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private UserAuthorityOfRole userAuthorityOfRole;
 
-	public UserRoleOfTeam(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, UserRole userRole,
-		UserAuthorityOfRole userAuthorityOfRole) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.userRole = userRole;
-		this.userAuthorityOfRole = userAuthorityOfRole;
-	}
+    public UserRoleOfTeam(Long id, UserRole userRole, UserAuthorityOfRole userAuthorityOfRole) {
+        this.id = id;
+        this.userRole = userRole;
+        this.userAuthorityOfRole = userAuthorityOfRole;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityConfig.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.initcloud.rocket23.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.initcloud.rocket23.security.entrypoint.TokenGlobalEntryPoint;
+import com.initcloud.rocket23.security.filter.TokenAuthenticationFilter;
+import com.initcloud.rocket23.security.provider.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenGlobalEntryPoint tokenGlobalEntryPoint;
+    private final JwtProvider jwtProvider;
+    private final SecurityProperties securityProperties;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .httpBasic().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/auth/**").permitAll()
+                .and()
+                .authorizeRequests()
+                .anyRequest().authenticated()
+                .and()
+                .exceptionHandling().authenticationEntryPoint(tokenGlobalEntryPoint)
+                .and()
+                .addFilterBefore(
+                        new TokenAuthenticationFilter(jwtProvider, securityProperties),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityProperties.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityProperties.java
@@ -1,0 +1,43 @@
+package com.initcloud.rocket23.security.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityProperties {
+
+	private final Environment environment;
+
+	@Getter
+	private String secret;
+
+	@Getter
+	private String githubClientId;
+
+	@Getter
+	private String githubClientSecret;
+
+	@Getter
+	private String githubRedirectUri;
+
+	@Getter
+	private String redirectUri;
+
+	@PostConstruct
+	public void initSecurityProperties() {
+		this.secret = environment.getProperty("JWT_SECRET");
+		this.githubClientId = environment.getProperty("GITHUB_CLIENT_ID");
+		this.githubClientSecret = environment.getProperty("GITHUB_CLIENT_SECRET");
+		this.githubRedirectUri = environment.getProperty("GITHUB_CALLBACK");
+		this.redirectUri = environment.getProperty("REDIRECT_URI");
+		log.info("[PROPERTIES] initialized.");
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/OAuthDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/OAuthDto.java
@@ -1,0 +1,55 @@
+package com.initcloud.rocket23.security.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import com.initcloud.rocket23.security.config.SecurityProperties;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class GithubTokenResponse {
+        private String accessToken;
+        private Long expiresIn;
+        private String refreshToken;
+        private Long refreshTokenExpiresIn;
+        private String scope;
+        private String tokenType;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class GithubTokenRequest {
+        private String clientId;
+        private String clientSecret;
+        private String code;
+        private String redirectUri;
+
+        public GithubTokenRequest(SecurityProperties properties, String code) {
+            this.clientId = properties.getGithubClientId();
+            this.clientSecret = properties.getGithubClientSecret();
+            this.redirectUri = properties.getGithubRedirectUri();
+            this.code = code;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class GithubUserDetail {
+        private String login;
+        private Long id;
+        private String avatarUrl;
+        private String name;
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/Token.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/Token.java
@@ -1,0 +1,18 @@
+package com.initcloud.rocket23.security.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Token {
+
+	private String accessToken;
+	private String refreshToken;
+
+	public Token(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/UsernameToken.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/dto/UsernameToken.java
@@ -1,0 +1,16 @@
+package com.initcloud.rocket23.security.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UsernameToken extends Token {
+	private String username;
+
+	public UsernameToken(String username, String accessToken, String refreshToken) {
+		super(accessToken, refreshToken);
+		this.username = username;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/entrypoint/TokenGlobalEntryPoint.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/entrypoint/TokenGlobalEntryPoint.java
@@ -1,0 +1,59 @@
+package com.initcloud.rocket23.security.entrypoint;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.simple.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+
+@Component("tokenGlobalEntryPoint")
+public class TokenGlobalEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		org.springframework.security.core.AuthenticationException authException) throws
+		IOException, ServletException {
+		Integer exception = (Integer)request.getAttribute("exception");
+
+		if (exception == null) {
+			setResponse(response, ResponseCode.INVALID_REQUEST);
+		} else if (exception.equals(ResponseCode.EMPTY_TOKEN_CLAIMS.getCode())) {
+			setResponse(response, ResponseCode.EMPTY_TOKEN_CLAIMS);
+		} else if (exception.equals(ResponseCode.INVALID_TOKEN_SIGNATURE.getCode())) {
+			setResponse(response, ResponseCode.INVALID_TOKEN_SIGNATURE);
+		} else if (exception.equals(ResponseCode.INVALID_TOKEN.getCode())) {
+			setResponse(response, ResponseCode.INVALID_TOKEN);
+		} else if (exception.equals(ResponseCode.TOKEN_EXPIRED.getCode())) {
+			setResponse(response, ResponseCode.TOKEN_EXPIRED);
+		} else if (exception.equals(ResponseCode.UNSUPPORTED_TOKEN.getCode())) {
+			setResponse(response, ResponseCode.UNSUPPORTED_TOKEN);
+		} else if (exception.equals(ResponseCode.INVALID_TOKEN_FORMAT.getCode())) {
+			setResponse(response, ResponseCode.INVALID_TOKEN_FORMAT);
+		} else {
+			setResponse(response, ResponseCode.INVALID_TOKEN);
+		}
+	}
+
+	private void setResponse(HttpServletResponse response, ResponseCode code) throws IOException {
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType("application/json");
+
+		JSONObject responseJson = new JSONObject();
+		JSONObject errorJson = new JSONObject();
+		errorJson.put("code", code.getCode());
+		errorJson.put("message", code.getMessage());
+
+		responseJson.put("success", false);
+		responseJson.put("data", null);
+		responseJson.put("error", errorJson);
+
+		response.getWriter().print(responseJson);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/facade/OAuthRequestFacade.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/facade/OAuthRequestFacade.java
@@ -1,0 +1,66 @@
+package com.initcloud.rocket23.security.facade;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiAuthException;
+import com.initcloud.rocket23.common.feign.OAuthFeignClient;
+import com.initcloud.rocket23.common.feign.OAuthInfoFeignClient;
+import com.initcloud.rocket23.security.config.SecurityProperties;
+import com.initcloud.rocket23.security.dto.OAuthDto;
+import com.initcloud.rocket23.security.dto.Token;
+import com.initcloud.rocket23.security.provider.JwtProvider;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRequestFacade {
+
+    private final OAuthFeignClient oauthFeignClient;
+    private final OAuthInfoFeignClient infoFeignClient;
+    private final JwtProvider jwtProvider;
+    private final SecurityProperties properties;
+
+    private static final String GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize?";
+
+    /**
+     * Request Github Access Token by auth code.
+     *
+     * @return access token in String
+     */
+    public String requestGithubOAuthToken(String code) {
+        OAuthDto.GithubTokenRequest tokenRequest = new OAuthDto.GithubTokenRequest(properties, code);
+        String resultString = oauthFeignClient.requestGithubAccessToken(tokenRequest);
+
+        String[] arr = resultString.split("&");
+
+        for (String s : arr) {
+            if (s.startsWith("access_token"))
+                return s;
+        }
+
+        throw new ApiAuthException(ResponseCode.INVALID_TOKEN);
+    }
+
+    /**
+     * Request Github User info by access token.
+     *
+     * @return user detail in OAuthDto.GithubUserDetail
+     */
+    public OAuthDto.GithubUserDetail requestGithubUserDetail(String accessToken) {
+        return infoFeignClient.requestGithubUserDetail("Bearer " + accessToken.split("=")[1]);
+    }
+
+    /**
+     * You can get user access token
+     *
+     * @return user access token in Token
+     */
+    public Token createSocialUserToken(String username) {
+        return jwtProvider.create(username, properties.getSecret());
+    }
+
+    public String getRedirectAuthUrl(String redirect) {
+        return GITHUB_AUTH_URL + "client_id=" + properties.getGithubClientId() + "&redirect_uri=" + redirect;
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/filter/TokenAuthenticationFilter.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.initcloud.rocket23.security.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.security.config.SecurityProperties;
+import com.initcloud.rocket23.security.provider.JwtProvider;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtProvider jwtTokenProvider;
+	private final SecurityProperties securityProperties;
+
+	private static final String EXCEPTION = "exception";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+		IOException, ServletException {
+		String token = jwtTokenProvider.resolve(request);
+		jwtTokenProvider.validate(token, securityProperties.getSecret());
+
+		try {
+			Authentication authentication = jwtTokenProvider.getAuthentication(token,
+				securityProperties.getSecret());
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		} catch (NullPointerException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.NULL_TOKEN.getCode());
+		} catch (SecurityException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.INVALID_TOKEN_SIGNATURE.getCode());
+		} catch (MalformedJwtException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.INVALID_TOKEN_FORMAT.getCode());
+		} catch (ExpiredJwtException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.TOKEN_EXPIRED.getCode());
+		} catch (UnsupportedJwtException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.UNSUPPORTED_TOKEN.getCode());
+		} catch (IllegalArgumentException e) {
+			request.setAttribute(EXCEPTION, ResponseCode.EMPTY_TOKEN_CLAIMS.getCode());
+		} catch (Exception e) {
+			request.setAttribute(EXCEPTION, ResponseCode.INVALID_TOKEN.getCode());
+		}
+
+		chain.doFilter(request, response);
+	}
+}
+

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/JwtProvider.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/JwtProvider.java
@@ -1,0 +1,114 @@
+package com.initcloud.rocket23.security.provider;
+
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.catalina.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiAuthException;
+import com.initcloud.rocket23.security.dto.Token;
+import com.initcloud.rocket23.security.dto.UsernameToken;
+import com.initcloud.rocket23.security.service.CustomUserDetailsService;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtProvider implements TokenProvider {
+
+    private final CustomUserDetailsService userDetailsService;
+
+    public Token create(String username, String key) {
+        Date now = new Date();
+        String accessToken = Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + EXPIREDTIME))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+
+        return new UsernameToken(username, accessToken, null);
+    }
+
+    public String getUsername(String token, String key) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    @Override
+    public boolean validate(String token, String key) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(key)
+                    .parseClaimsJws(token);
+
+            return true;
+        } catch (SecurityException e) {
+            log.error(ResponseCode.INVALID_TOKEN_SIGNATURE.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.INVALID_TOKEN_SIGNATURE);
+        } catch (MalformedJwtException e) {
+            log.error(ResponseCode.INVALID_TOKEN.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.error(ResponseCode.TOKEN_EXPIRED.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.TOKEN_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            log.error(ResponseCode.UNSUPPORTED_TOKEN.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error(ResponseCode.EMPTY_TOKEN_CLAIMS.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.EMPTY_TOKEN_CLAIMS);
+        } catch (Exception e) {
+            log.error(ResponseCode.INVALID_TOKEN.getMessage(), e.getMessage());
+            throw new ApiAuthException(ResponseCode.INVALID_TOKEN);
+        }
+    }
+
+    public String resolve(HttpServletRequest request) {
+
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null)
+            throw new ApiAuthException(ResponseCode.NULL_TOKEN);
+
+        if (authorization.startsWith("Bearer "))
+            return authorization.substring(7);
+
+        if (authorization.startsWith("token "))
+            return authorization.substring(6);
+
+        throw new ApiAuthException(ResponseCode.INVALID_TOKEN);
+    }
+
+    public String getUsername() {
+        return ((User) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal())
+                .getUsername();
+    }
+
+    public Authentication getAuthentication(String token, String key) {
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUsername(token, key));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/TokenProvider.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/TokenProvider.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.security.provider;
+
+public interface TokenProvider {
+
+	long EXPIREDTIME = 3 * 24 * 60 * 60 * 1000L;
+
+	boolean validate(String token, String key);
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/UsernamePasswordAuthenticateProvider.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/provider/UsernamePasswordAuthenticateProvider.java
@@ -1,0 +1,39 @@
+package com.initcloud.rocket23.security.provider;
+
+import com.initcloud.rocket23.security.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class UsernamePasswordAuthenticateProvider implements AuthenticationProvider {
+
+    private final CustomUserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String name = authentication.getName();
+        String password = authentication.getCredentials().toString();
+        UserDetails user = userDetailsService.loadUserByUsername(name);
+
+        if (!passwordEncoder.matches(password, user.getPassword()))
+            throw new BadCredentialsException("Bad Credentials.");
+
+        return new UsernamePasswordAuthenticationToken(user, password);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/service/AuthService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.security.service;
+
+import com.initcloud.rocket23.security.dto.Token;
+
+public interface AuthService {
+
+    Token getUserAccessToken(String code);
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/service/CustomUserDetailsService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.initcloud.rocket23.security.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiAuthException;
+import com.initcloud.rocket23.infra.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		return userRepository.findUserByUsername(username)
+			.orElseThrow(
+				() -> new ApiAuthException(ResponseCode.INVALID_CREDENTIALS)
+			);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/service/OAuthService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/service/OAuthService.java
@@ -1,0 +1,72 @@
+package com.initcloud.rocket23.security.service;
+
+import com.initcloud.rocket23.common.enums.ResponseCode;
+import com.initcloud.rocket23.common.exception.ApiAuthException;
+import com.initcloud.rocket23.infra.repository.UserRepository;
+import com.initcloud.rocket23.security.config.SecurityProperties;
+import com.initcloud.rocket23.security.dto.OAuthDto;
+import com.initcloud.rocket23.security.dto.Token;
+import com.initcloud.rocket23.security.facade.OAuthRequestFacade;
+import com.initcloud.rocket23.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthService implements AuthService {
+
+    private final UserRepository userRepository;
+    private final OAuthRequestFacade oauthRequestFacade;
+    private final SecurityProperties properties;
+
+    @Override
+    public Token getUserAccessToken(String code) {
+        String tokenResponse = oauthRequestFacade.requestGithubOAuthToken(code);
+        OAuthDto.GithubUserDetail userDetail = oauthRequestFacade.requestGithubUserDetail(tokenResponse);
+
+        User user = getUserIfExist(userDetail);
+
+        return oauthRequestFacade.createSocialUserToken(user.getUsername());
+    }
+
+    public void redirectGithub(HttpServletResponse response, String redirect) {
+        try {
+            String url = oauthRequestFacade.getRedirectAuthUrl(redirect);
+            response.sendRedirect(url);
+        } catch (IOException e) {
+            throw new ApiAuthException(ResponseCode.INVALID_CREDENTIALS);
+        }
+    }
+
+    /**
+     * Todo
+     * Initialize UsedRule from CustomRule for new User.
+     */
+    private void initializeUserRules(User user) {
+
+    }
+
+    /**
+     * @return registered User
+     */
+    public User getUserIfExist(OAuthDto.GithubUserDetail userDetail) {
+        Optional<User> user = userRepository.findUserByUsername(userDetail.getLogin());
+
+        if (user.isPresent())
+            return user.get();
+
+        User socialUser = userRepository.save(User.addIndividualSocialUser(userDetail));
+
+        initializeUserRules(socialUser);
+
+        return socialUser;
+    }
+
+
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamInspectController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamInspectController.java
@@ -1,0 +1,25 @@
+package com.initcloud.rocket23.team.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+
+@RestController
+@RequestMapping("/team")
+public class TeamInspectController {
+
+	@GetMapping
+	public ResponseDto<Object> memberList() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+	@GetMapping("/{memberName}")
+	public ResponseDto<Object> memberDetails(@PathVariable String memberName) {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamManageController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamManageController.java
@@ -1,0 +1,25 @@
+package com.initcloud.rocket23.team.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+
+@RestController
+@RequestMapping("/team")
+public class TeamManageController {
+
+	@PutMapping("/status")
+	public ResponseDto<Object> memberStatus() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+	@DeleteMapping
+	public ResponseDto<Object> teamRemove() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamProjectController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamProjectController.java
@@ -1,0 +1,26 @@
+package com.initcloud.rocket23.team.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+
+@RestController
+@RequestMapping("/team/project")
+public class TeamProjectController {
+
+	public ResponseDto<Object> projectList() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+	public ResponseDto<Object> projectDetails() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+	public ResponseDto<Object> projectAdd() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/Team.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/Team.java
@@ -1,0 +1,35 @@
+package com.initcloud.rocket23.team.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	private String logoUri;
+
+	public Team(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String name,
+		String logoUri) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.name = name;
+		this.logoUri = logoUri;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/Team.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/Team.java
@@ -17,19 +17,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private String name;
+    private String name;
 
-	private String logoUri;
+    private String logoUri;
 
-	public Team(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, String name,
-		String logoUri) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.name = name;
-		this.logoUri = logoUri;
-	}
+    public Team(Long id, String name, String logoUri) {
+        this.id = id;
+        this.name = name;
+        this.logoUri = logoUri;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/TeamWithUsers.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/TeamWithUsers.java
@@ -21,32 +21,30 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamWithUsers extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	private Boolean isAdmin;
+    private Boolean isAdmin;
 
-	private String roleType;
+    private String roleType;
 
-	private String authorities;
+    private String authorities;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private Team team;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Team team;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn
-	private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private User user;
 
-	public TeamWithUsers(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, Boolean isAdmin,
-		String roleType, String authorities, Team team, User user) {
-		super(createdAt, modifiedAt);
-		this.id = id;
-		this.isAdmin = isAdmin;
-		this.roleType = roleType;
-		this.authorities = authorities;
-		this.team = team;
-		this.user = user;
-	}
+    public TeamWithUsers(Long id, Boolean isAdmin, String roleType, String authorities, Team team, User user) {
+        this.id = id;
+        this.isAdmin = isAdmin;
+        this.roleType = roleType;
+        this.authorities = authorities;
+        this.team = team;
+        this.user = user;
+    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/TeamWithUsers.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/entity/TeamWithUsers.java
@@ -1,0 +1,52 @@
+package com.initcloud.rocket23.team.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+import com.initcloud.rocket23.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamWithUsers extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Boolean isAdmin;
+
+	private String roleType;
+
+	private String authorities;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Team team;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private User user;
+
+	public TeamWithUsers(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, Boolean isAdmin,
+		String roleType, String authorities, Team team, User user) {
+		super(createdAt, modifiedAt);
+		this.id = id;
+		this.isAdmin = isAdmin;
+		this.roleType = roleType;
+		this.authorities = authorities;
+		this.team = team;
+		this.user = user;
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamInspectService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamInspectService.java
@@ -1,0 +1,20 @@
+package com.initcloud.rocket23.team.service;
+
+import org.springframework.stereotype.Service;
+
+import com.initcloud.rocket23.infra.repository.TeamRepository;
+import com.initcloud.rocket23.infra.repository.TeamWithUsersRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TeamInspectService {
+
+	private final TeamRepository teamRepository;
+	private final TeamWithUsersRepository teamWithUsersRepository;
+
+	public void getTeamDetails() {
+		//Todo
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamManageService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamManageService.java
@@ -1,0 +1,20 @@
+package com.initcloud.rocket23.team.service;
+
+import org.springframework.stereotype.Service;
+
+import com.initcloud.rocket23.infra.repository.TeamRepository;
+import com.initcloud.rocket23.infra.repository.TeamWithUsersRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TeamManageService {
+
+	private final TeamRepository teamRepository;
+	private final TeamWithUsersRepository teamWithUsersRepository;
+
+	public void withdrawalTeam() {
+		//Todo
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamProjectService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/service/TeamProjectService.java
@@ -1,0 +1,8 @@
+package com.initcloud.rocket23.team.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamProjectService {
+    //Todo
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/AuthController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.initcloud.rocket23.user.controller;
+
+import com.initcloud.rocket23.security.dto.Token;
+import com.initcloud.rocket23.security.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final OAuthService authService;
+
+	public ResponseDto<Object> githubUserRegister() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+	public ResponseDto<Object> githubUserJoin() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+
+
+	public void githubAuthRedirect(HttpServletResponse response, @RequestParam("redirect") String redirect) {
+		authService.redirectGithub(response, redirect);
+	}
+
+	@GetMapping("/callback")
+	public ResponseDto<Token> githubAuth(@RequestParam("code") String authCode) {
+		Token response = authService.getUserAccessToken(authCode);
+
+		return new ResponseDto<>(response);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/UserController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/UserController.java
@@ -1,0 +1,16 @@
+package com.initcloud.rocket23.user.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.initcloud.rocket23.common.dto.ResponseDto;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+	public ResponseDto<Object> profileDetails() {
+		//Todo
+		return new ResponseDto<>(null);
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/entity/User.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/entity/User.java
@@ -1,0 +1,101 @@
+package com.initcloud.rocket23.user.entity;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.initcloud.rocket23.security.dto.OAuthDto;
+import com.initcloud.rocket23.user.enums.AuthProvider;
+import com.initcloud.rocket23.user.enums.UserState;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime lastLogin;
+
+    private String username;
+
+    private String password;
+
+    private String profileImageUrl;
+
+    private String contact;
+
+    private String email;
+
+    public User(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, LocalDateTime lastLogin, String username,
+                String password, String profileImageUrl, String contact, String email) {
+        super(createdAt, modifiedAt);
+        this.id = id;
+        this.lastLogin = lastLogin;
+        this.username = username;
+        this.password = password;
+        this.profileImageUrl = profileImageUrl;
+        this.contact = contact;
+        this.email = email;
+    }
+
+    /**
+     * Constructor for Individual social User
+     */
+    public User(String username, String nickname, AuthProvider oAuthProvider, UserState userState) {
+        super(LocalDateTime.now(), LocalDateTime.now());
+        this.lastLogin = LocalDateTime.now();
+        this.username = username;
+        this.password = "";
+        this.email = "";
+        this.contact = "";
+    }
+
+    /**
+     * Add Social User with Github, has no team.
+     * @return User
+     */
+    public static User addIndividualSocialUser(OAuthDto.GithubUserDetail detail) {
+        return new User(detail.getLogin(), detail.getName(), AuthProvider.GITHUB, UserState.ACTIVATE);
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/entity/User.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/entity/User.java
@@ -41,9 +41,7 @@ public class User extends BaseEntity implements UserDetails {
 
     private String email;
 
-    public User(LocalDateTime createdAt, LocalDateTime modifiedAt, Long id, LocalDateTime lastLogin, String username,
-                String password, String profileImageUrl, String contact, String email) {
-        super(createdAt, modifiedAt);
+    public User(Long id, LocalDateTime lastLogin, String username, String password, String profileImageUrl, String contact, String email) {
         this.id = id;
         this.lastLogin = lastLogin;
         this.username = username;
@@ -57,7 +55,6 @@ public class User extends BaseEntity implements UserDetails {
      * Constructor for Individual social User
      */
     public User(String username, String nickname, AuthProvider oAuthProvider, UserState userState) {
-        super(LocalDateTime.now(), LocalDateTime.now());
         this.lastLogin = LocalDateTime.now();
         this.username = username;
         this.password = "";
@@ -67,6 +64,7 @@ public class User extends BaseEntity implements UserDetails {
 
     /**
      * Add Social User with Github, has no team.
+     *
      * @return User
      */
     public static User addIndividualSocialUser(OAuthDto.GithubUserDetail detail) {

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/enums/AuthProvider.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/enums/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.initcloud.rocket23.user.enums;
+
+public enum AuthProvider {
+	GITHUB
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/enums/UserState.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/enums/UserState.java
@@ -1,0 +1,9 @@
+package com.initcloud.rocket23.user.enums;
+
+
+import lombok.Getter;
+
+@Getter
+public enum UserState {
+    ACTIVATE, DEACTIVATE, DELETED
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/service/UserService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/service/UserService.java
@@ -1,0 +1,30 @@
+package com.initcloud.rocket23.user.service;
+
+import com.initcloud.rocket23.infra.repository.UserRepository;
+import com.initcloud.rocket23.security.service.CustomUserDetailsService;
+
+public class UserService extends CustomUserDetailsService {
+	public UserService(UserRepository userRepository) {
+		super(userRepository);
+	}
+
+	public void getUserList() {
+
+	}
+
+	public void getUserDetails() {
+
+	}
+
+	public void modifyUserProfile() {
+
+	}
+
+	public void removeUserProfile() {
+
+	}
+
+	public void modifyUserStatus() {
+
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ rootProject.name = 'rocket23'
 include 'docker'
 include 'file'
 include 'restdocs'
+include 'scanhistory'
 


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #32

## Update Summary
- Github 기반의 토큰 기반 인증을 구현.
- User 및 Team 관리를 위한 스켈레톤 컨트롤러, 서비스 및 엔티티 구현.
- Spring Cloud OpenFeign 기반의 API 요청 구조화.

## New/Edited policies
- 토큰 기반 인증을 사용합니다.
- Advice 기반으로 인증-인가에 대한 에러를 핸들링합니다.
- 기존 계획이었던 유저-팀 권한 관리에 우선하여 인증-인가를 먼저 구현합니다.

## Resolved Issue
- 

## Unresolved Issue
- DB 데이터 소스 미연결
- 유저-팀 권한 관리 기능으로 연결하여 미구현부를 완성할 계획입니다.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [ ] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.