### PR TITLE
[IC-76] feat: 단일 스캔 이력 조회(실패 내역 조회)

### DIFF
--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -2,10 +2,12 @@ package com.initcloud.rocket23.checklist.controller;
 
 import java.util.List;
 
+import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
 import com.initcloud.rocket23.checklist.dto.ScanHistoryDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 import com.initcloud.rocket23.checklist.service.ScanHistoryService;
 import com.initcloud.rocket23.common.dto.ResponseDto;
+import com.initcloud.rocket23.team.dto.TeamInviteDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +33,16 @@ public class ScanHistoryController {
 		@PathVariable("projectCode") Long projectCode, @PathVariable("hashCode") String hashCode) {
 		ScanResultDto dto = scanHistoryService.getScanHistory(teamCode, projectCode, hashCode);
 		return new ResponseDto<>(dto);
+	}
+
+	/*
+		단일 스캔 실패 내역에 대한 조회
+	 */
+	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/{hashCode}/fail")
+	public ResponseDto<ScanFailDetailDto> getScanFailDeatil(@PathVariable("teamCode") Long teamCode,
+		@PathVariable("projectCode") Long projectCode, @PathVariable("hashCode") String hashCode) {
+		ScanFailDetailDto dtos = scanHistoryService.getScanFailDetail(teamCode, projectCode, hashCode);
+		return new ResponseDto<>(dtos);
 	}
 	/**
 	 * get 방식을 통해 file scan history 내역을 최근 10개를 출력하도록함.

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -29,8 +29,8 @@ public class ScanHistoryController {
 	 * 단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
 	 */
 	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/{hashCode}")
-	public ResponseDto<ScanResultDto> getScanHistory(@PathVariable("teamCode") Long teamCode,
-		@PathVariable("projectCode") Long projectCode, @PathVariable("hashCode") String hashCode) {
+	public ResponseDto<ScanResultDto> getScanHistory(@PathVariable("teamCode") String teamCode,
+		@PathVariable("projectCode") String projectCode, @PathVariable("hashCode") String hashCode) {
 		ScanResultDto dto = scanHistoryService.getScanHistory(teamCode, projectCode, hashCode);
 		return new ResponseDto<>(dto);
 	}
@@ -39,8 +39,8 @@ public class ScanHistoryController {
 		단일 스캔 실패 내역에 대한 조회
 	 */
 	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/{hashCode}/fail")
-	public ResponseDto<ScanFailDetailDto> getScanFailDeatil(@PathVariable("teamCode") Long teamCode,
-		@PathVariable("projectCode") Long projectCode, @PathVariable("hashCode") String hashCode) {
+	public ResponseDto<ScanFailDetailDto> getScanFailDeatil(@PathVariable("teamCode") String teamCode,
+		@PathVariable("projectCode") String projectCode, @PathVariable("hashCode") String hashCode) {
 		ScanFailDetailDto dtos = scanHistoryService.getScanFailDetail(teamCode, projectCode, hashCode);
 		return new ResponseDto<>(dtos);
 	}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
@@ -1,0 +1,46 @@
+package com.initcloud.rocket23.checklist.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.initcloud.rocket23.checklist.entity.ScanHistory;
+import com.initcloud.rocket23.checklist.entity.ScanHistoryDetail;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScanFailDetailDto {
+	private int high;
+	private int low;
+	private int medium;
+	private int unknown;
+	private List<FailResource> failResourceList;
+
+	private static class FailResource {
+		private String ruleName;
+		private String resource;
+		private String resourceName;
+
+		private FailResource(String ruleName, String resource, String resourceName) {
+			this.ruleName = ruleName;
+			this.resource = resource;
+			this.resourceName = resourceName;
+		}
+	}
+
+	public ScanFailDetailDto(ScanHistory scanHistory, List<ScanHistoryDetail> scanHistoryDetail) {
+		this.high = scanHistory.getHigh();
+		this.low = scanHistory.getLow();
+		this.medium = scanHistory.getMedium();
+		this.unknown = scanHistory.getUnknown();
+		failResourceList = new ArrayList<>();
+		for (ScanHistoryDetail detail : scanHistoryDetail) {
+			failResourceList.add(
+				new FailResource(detail.getRuleName(), detail.getResource(), detail.getResourceName()));
+		}
+
+	}
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
@@ -2,6 +2,7 @@ package com.initcloud.rocket23.checklist.dto;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
 import com.initcloud.rocket23.checklist.entity.ScanHistoryDetail;
@@ -39,10 +40,9 @@ public class ScanFailDetailDto {
 		this.medium = scanHistory.getMedium();
 		this.unknown = scanHistory.getUnknown();
 		this.failResourceList = new ArrayList<>();
-		for (ScanHistoryDetail detail : scanHistoryDetails) {
-			failResourceList.add(
-				new FailResource(detail.getRuleName(), detail.getResource(), detail.getResourceName()));
-		}
+		failResourceList.addAll(scanHistoryDetails.stream()
+			.map(detail -> new FailResource(detail.getRuleName(), detail.getResource(), detail.getResourceName()))
+			.collect(Collectors.toList()));
 
 	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
@@ -19,6 +19,8 @@ public class ScanFailDetailDto {
 	private int unknown;
 	private List<FailResource> failResourceList;
 
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	private static class FailResource {
 		private String ruleName;
 		private String resource;
@@ -31,13 +33,13 @@ public class ScanFailDetailDto {
 		}
 	}
 
-	public ScanFailDetailDto(ScanHistory scanHistory, List<ScanHistoryDetail> scanHistoryDetail) {
+	public ScanFailDetailDto(ScanHistory scanHistory, List<ScanHistoryDetail> scanHistoryDetails) {
 		this.high = scanHistory.getHigh();
 		this.low = scanHistory.getLow();
 		this.medium = scanHistory.getMedium();
 		this.unknown = scanHistory.getUnknown();
-		failResourceList = new ArrayList<>();
-		for (ScanHistoryDetail detail : scanHistoryDetail) {
+		this.failResourceList = new ArrayList<>();
+		for (ScanHistoryDetail detail : scanHistoryDetails) {
 			failResourceList.add(
 				new FailResource(detail.getRuleName(), detail.getResource(), detail.getResourceName()));
 		}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistoryDetail.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistoryDetail.java
@@ -8,60 +8,72 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
+import com.initcloud.rocket23.common.entity.BaseEntity;
+
 @Getter
 @Entity
 @Table(name = "SCAN_HISTORY_DETAIL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ScanHistoryDetail {
+public class ScanHistoryDetail extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "SCANHISTORYDETAIL_ID")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "SCANHISTORY_DETAIL_ID")
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "HISTORY_ID")
-    private ScanHistory scanHistory;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "HISTORY_ID")
+	private ScanHistory scanHistory;
 
-    @Column(name = "CHECK_TYPE")
-    @NotNull
-    private String checkType;
+	@Column(name = "CHECK_TYPE")
+	@NotNull
+	private String checkType;
 
-    @Column(name = "TARGET_FILE_NAME")
-    @NotNull
-    private String targetFileName;
+	@Column(name = "APP_TYPE")
+	@NotNull
+	private String appType;
 
-    @Column(name = "APP_TYPE")
-    @NotNull
-    private String appType;
+	@Column(name = "SCAN_RESULT")
+	@NotNull
+	private String scanResult;
 
-    @Column(name = "PROVIDER")
-    @NotNull
-    private String provider;
+	@Column(name = "TARGET_FILE_NAME")
+	@NotNull
+	private String targetFileName;
 
-    @Column(name = "SCAN_RESULT")
-    @NotNull
-    private String scanResult;
+	@Column(name = "LINE")
+	@NotNull
+	private String line;
 
-    @Column(name = "LINE")
-    @NotNull
-    private String line;
+	@Column(name = "CODE")
+	@NotNull
+	private String code;
 
-    @Column(name = "CODE")
-    @NotNull
-    private String code;
+	@Column(name = "RESOURCE")
+	@NotNull
+	private String resource;
 
-    @Builder
-    public ScanHistoryDetail(ScanHistory scanHistory, String checkType,
-                             String targetFileName, String appType, String provider, String scanResult, String line, String code) {
-        this.scanHistory = scanHistory;
-        this.checkType = checkType;
-        this.targetFileName = targetFileName;
-        this.appType = appType;
-        this.provider = provider;
-        this.scanResult = scanResult;
-        this.line = line;
-        this.code = code;
-        scanHistory.getScanDetails().add(this);
-    }
+	@Column(name = "RESOURCE_NAME")
+	@NotNull
+	private String resourceName;
+
+	@Column(name = "RULE_NAME")
+	@NotNull
+	private String ruleName;
+
+	@Builder
+	public ScanHistoryDetail(ScanHistory scanHistory, String checkType,
+		String targetFileName, String appType, String scanResult, String line, String code, String resource, String resourceName,String ruleName) {
+		this.scanHistory = scanHistory;
+		this.checkType = checkType;
+		this.targetFileName = targetFileName;
+		this.appType = appType;
+		this.scanResult = scanResult;
+		this.line = line;
+		this.code = code;
+		this.resource = resource;
+		this.resourceName = resourceName;
+		this.ruleName = ruleName;
+		scanHistory.getScanDetails().add(this);
+	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -33,8 +33,8 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 		단일 스캔 내역 조회
 	 */
 	@Override
-	public ScanResultDto getScanHistory(Long teamCode, Long projectCode, String hashCode) {
-		ScanHistory scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
+	public ScanResultDto getScanHistory(String teamCode, String projectCode, String hashCode) {
+		ScanHistory scanHistory = scanHistoryRepository.findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(
 			teamCode,
 			projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
 		return new ScanResultDto(scanHistory);
@@ -44,8 +44,8 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 		단일 스캔에서 실패 내역 조회.
 	 */
 	@Override
-	public ScanFailDetailDto getScanFailDetail(Long teamCode, Long projectCode, String hashCode) {
-		ScanHistory scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
+	public ScanFailDetailDto getScanFailDetail(String teamCode, String projectCode, String hashCode) {
+		ScanHistory scanHistory = scanHistoryRepository.findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(
 			teamCode,
 			projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
 		List<ScanHistoryDetail> scanHistoryDetails = scanHistory.getScanDetails()
@@ -56,17 +56,17 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 		return new ScanFailDetailDto(scanHistory, scanHistoryDetails);
 	}
 	// @Override
-	// public List<HistoryDto> getHistoryList(Long teamId, Long projectId) {
+	// public List<HistoryDto> getHistoryList(String teamId, String projectId) {
 	// 	return null;
 	// }
 	//
 	// @Override
-	// public Page<HistoryDto> getOffsetPageHistoryList(Long teamId, Long projectId, Pageable page) {
+	// public Page<HistoryDto> getOffsetPageHistoryList(String teamId, String projectId, Pageable page) {
 	// 	return null;
 	// }
 	//
 	// @Override
-	// public CursorResultDto getCursorPageHistoryList(Long teamId, Long cursorId, Pageable Page) {
+	// public CursorResultDto getCursorPageHistoryList(String teamId, String cursorId, Pageable Page) {
 	// 	return null;
 	// }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -34,13 +34,10 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 	 */
 	@Override
 	public ScanResultDto getScanHistory(Long teamCode, Long projectCode, String hashCode) {
-		Optional<ScanHistory> scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
+		ScanHistory scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
 			teamCode,
-			projectCode, hashCode);
-		if (!scanHistory.isPresent()) {
-			throw new ApiException(ResponseCode.NO_SCAN_RESULT);
-		}
-		return new ScanResultDto(scanHistory.get());
+			projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
+		return new ScanResultDto(scanHistory);
 	}
 
 	/*
@@ -48,18 +45,15 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 	 */
 	@Override
 	public ScanFailDetailDto getScanFailDetail(Long teamCode, Long projectCode, String hashCode) {
-		Optional<ScanHistory> scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
+		ScanHistory scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
 			teamCode,
-			projectCode, hashCode);
-		if (!scanHistory.isPresent()) {
-			throw new ApiException(ResponseCode.NO_SCAN_RESULT);
-		}
-		List<ScanHistoryDetail> scanHistoryDetails = scanHistory.get().getScanDetails()
+			projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
+		List<ScanHistoryDetail> scanHistoryDetails = scanHistory.getScanDetails()
 			.stream()
 			.filter(scanHistoryDetail -> "failed".equals(scanHistoryDetail.getScanResult()))
 			.collect(Collectors.toList());
 
-		return new ScanFailDetailDto(scanHistory.get(), scanHistoryDetails);
+		return new ScanFailDetailDto(scanHistory, scanHistoryDetails);
 	}
 	// @Override
 	// public List<HistoryDto> getHistoryList(Long teamId, Long projectId) {

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -2,8 +2,10 @@ package com.initcloud.rocket23.checklist.service.Impl;
 
 import com.initcloud.rocket23.checklist.dto.CursorResultDto;
 import com.initcloud.rocket23.checklist.dto.HistoryDto;
+import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
+import com.initcloud.rocket23.checklist.entity.ScanHistoryDetail;
 import com.initcloud.rocket23.checklist.service.ScanHistoryService;
 import com.initcloud.rocket23.common.enums.ResponseCode;
 import com.initcloud.rocket23.common.exception.ApiException;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.swing.text.html.Option;
 
@@ -26,6 +29,9 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 
 	private final ScanHistoryRepository scanHistoryRepository;
 
+	/*
+		단일 스캔 내역 조회
+	 */
 	@Override
 	public ScanResultDto getScanHistory(Long teamCode, Long projectCode, String hashCode) {
 		Optional<ScanHistory> scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
@@ -37,6 +43,24 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 		return new ScanResultDto(scanHistory.get());
 	}
 
+	/*
+		단일 스캔에서 실패 내역 조회.
+	 */
+	@Override
+	public ScanFailDetailDto getScanFailDetail(Long teamCode, Long projectCode, String hashCode) {
+		Optional<ScanHistory> scanHistory = scanHistoryRepository.findTopByTeamIdAndProjectIdAndFileHashOrderById(
+			teamCode,
+			projectCode, hashCode);
+		if (!scanHistory.isPresent()) {
+			throw new ApiException(ResponseCode.NO_SCAN_RESULT);
+		}
+		List<ScanHistoryDetail> scanHistoryDetails = scanHistory.get().getScanDetails()
+			.stream()
+			.filter(scanHistoryDetail -> "failed".equals(scanHistoryDetail.getScanResult()))
+			.collect(Collectors.toList());
+
+		return new ScanFailDetailDto(scanHistory.get(), scanHistoryDetails);
+	}
 	// @Override
 	// public List<HistoryDto> getHistoryList(Long teamId, Long projectId) {
 	// 	return null;

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
@@ -11,12 +11,12 @@ import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 
 public interface ScanHistoryService {
-	ScanResultDto getScanHistory(Long teamId, Long projectId, String fileHash);
+	ScanResultDto getScanHistory(String teamCode, String projectCode, String fileHash);
 
-	ScanFailDetailDto	getScanFailDetail(Long teamId, Long projectId, String fileHash);
-	// List<HistoryDto> getHistoryList(Long teamId, Long projectId);
+	ScanFailDetailDto getScanFailDetail(String teamCode, String projectCode, String fileHash);
+	// List<HistoryDto> getHistoryList(String teamCode, String projectCode,;
 	//
-	// Page<HistoryDto> getOffsetPageHistoryList(Long teamId, Long projectId, Pageable page);
+	// Page<HistoryDto> getOffsetPageHistoryList(String teamCode, String projectCode, Pageable page);
 	//
-	// CursorResultDto getCursorPageHistoryList(Long teamId, Long cursorId, Pageable Page);
+	// CursorResultDto getCursorPageHistoryList(String teamCode, String cursorId, Pageable Page);
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
@@ -7,10 +7,13 @@ import org.springframework.data.domain.Pageable;
 
 import com.initcloud.rocket23.checklist.dto.CursorResultDto;
 import com.initcloud.rocket23.checklist.dto.HistoryDto;
+import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 
 public interface ScanHistoryService {
 	ScanResultDto getScanHistory(Long teamId, Long projectId, String fileHash);
+
+	ScanFailDetailDto	getScanFailDetail(Long teamId, Long projectId, String fileHash);
 	// List<HistoryDto> getHistoryList(Long teamId, Long projectId);
 	//
 	// Page<HistoryDto> getOffsetPageHistoryList(Long teamId, Long projectId, Pageable page);

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
@@ -1,5 +1,7 @@
 package com.initcloud.rocket23.infra.repository;
 
+import java.util.Optional;
+
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScanHistoryRepository extends JpaRepository<ScanHistory, Long> {
-
+	Optional<ScanHistory> findTopByTeamIdAndProjectIdAndFileHashOrderById(Long teamId, Long projectId, String hashCode);
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
@@ -9,5 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScanHistoryRepository extends JpaRepository<ScanHistory, Long> {
-	Optional<ScanHistory> findTopByTeamIdAndProjectIdAndFileHashOrderById(Long teamId, Long projectId, String hashCode);
+	Optional<ScanHistory> findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(String teamCode,
+		String projectCode, String hashCode);
 }


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #45 

## Update Summary
- 단일 스캔 이력 조회 중 실패 내역에 대한 조회 기능을 개발했습니다.

## New/Edited policies
- 실패 내역은 위험도 점수와 실패내역에 대한 리스트(리소스이름, 리소스, 관련 룰)을 보여줍니다.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [x] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.