### PR TITLE
[IC-78] feat: 단일 스캔 이력 페이징 처리

### DIFF
--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -1,16 +1,14 @@
 package com.initcloud.rocket23.checklist.controller;
 
-import java.util.List;
-
 import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
-import com.initcloud.rocket23.checklist.dto.ScanHistoryDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 import com.initcloud.rocket23.checklist.service.ScanHistoryService;
 import com.initcloud.rocket23.common.dto.ResponseDto;
-import com.initcloud.rocket23.team.dto.TeamInviteDto;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +21,7 @@ public class ScanHistoryController {
 
 	private final ScanHistoryService scanHistoryService;
 
-	private final int DEFAULT_SIZE = 10;
+	//private final int DEFAULT_SIZE = 10;
 
 	/**
 	 * 단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
@@ -35,6 +33,14 @@ public class ScanHistoryController {
 		return new ResponseDto<>(dto);
 	}
 
+	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/")
+	public ResponseDto<Page<ScanResultDto.Summary>> getScanHistoryPaging(@PathVariable("teamCode") String teamCode,
+		@PathVariable("projectCode")
+		String projectCode, final Pageable pageable) {
+		Page<ScanResultDto.Summary> dtos = scanHistoryService.getScanHistoryPaging(teamCode, projectCode, pageable);
+		return new ResponseDto<>(dtos);
+	}
+
 	/*
 		단일 스캔 실패 내역에 대한 조회
 	 */
@@ -44,6 +50,7 @@ public class ScanHistoryController {
 		ScanFailDetailDto dtos = scanHistoryService.getScanFailDetail(teamCode, projectCode, hashCode);
 		return new ResponseDto<>(dtos);
 	}
+
 	/**
 	 * get 방식을 통해 file scan history 내역을 최근 10개를 출력하도록함.
 	 *

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -23,8 +23,8 @@ public class ScanHistoryController {
 
 	//private final int DEFAULT_SIZE = 10;
 
-	/**
-	 * 단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
+	/*
+		단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
 	 */
 	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/{hashCode}")
 	public ResponseDto<ScanResultDto> getScanHistory(@PathVariable("teamCode") String teamCode,
@@ -33,7 +33,10 @@ public class ScanHistoryController {
 		return new ResponseDto<>(dto);
 	}
 
-	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/")
+	/*
+		단일 스캔 이력 Pagination
+	 */
+	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history")
 	public ResponseDto<Page<ScanResultDto.Summary>> getScanHistoryPaging(@PathVariable("teamCode") String teamCode,
 		@PathVariable("projectCode")
 		String projectCode, final Pageable pageable) {

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanHistoryDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanHistoryDto.java
@@ -1,6 +1,5 @@
 package com.initcloud.rocket23.checklist.dto;
 
-
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
 
 import lombok.AccessLevel;

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
@@ -39,7 +39,7 @@ public class ScanResultDto {
 		private Integer skipped;
 		private Integer failed;
 
-		public Summary(ScanHistory entity){
+		public Summary(ScanHistory entity) {
 			this.fileName = entity.getFileName();
 			this.passed = entity.getPassed();
 			this.skipped = entity.getSkipped();

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
@@ -30,4 +30,20 @@ public class ScanResultDto {
 		this.failed = entity.getFailed();
 		this.skipped = entity.getSkipped();
 	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class Summary {
+		private String fileName;
+		private Integer passed;
+		private Integer skipped;
+		private Integer failed;
+
+		public Summary(ScanHistory entity){
+			this.fileName = entity.getFileName();
+			this.passed = entity.getPassed();
+			this.skipped = entity.getSkipped();
+			this.failed = entity.getFailed();
+		}
+	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -47,9 +47,6 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 	public Page<ScanResultDto.Summary> getScanHistoryPaging(String teamCode, String projectCode, Pageable pageable) {
 		Page<ScanHistory> scanHistories = scanHistoryRepository.findAllByTeam_TeamCodeAndProject_ProjectCode(pageable,
 			teamCode, projectCode);
-		if (scanHistories.isEmpty()) {
-			throw new ApiException(ResponseCode.NO_SCAN_RESULT);
-		}
 		return scanHistories.map(ScanResultDto.Summary::new);
 	}
 

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -41,6 +41,19 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 	}
 
 	/*
+		단일 스캔 내역 페이징 처리
+	 */
+	@Override
+	public Page<ScanResultDto.Summary> getScanHistoryPaging(String teamCode, String projectCode, Pageable pageable) {
+		Page<ScanHistory> scanHistories = scanHistoryRepository.findAllByTeam_TeamCodeAndProject_ProjectCode(pageable,
+			teamCode, projectCode);
+		if (scanHistories.isEmpty()) {
+			throw new ApiException(ResponseCode.NO_SCAN_RESULT);
+		}
+		return scanHistories.map(ScanResultDto.Summary::new);
+	}
+
+	/*
 		단일 스캔에서 실패 내역 조회.
 	 */
 	@Override

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
@@ -14,6 +14,8 @@ public interface ScanHistoryService {
 	ScanResultDto getScanHistory(String teamCode, String projectCode, String fileHash);
 
 	ScanFailDetailDto getScanFailDetail(String teamCode, String projectCode, String fileHash);
+
+	Page<ScanResultDto.Summary>	getScanHistoryPaging(String teamCode, String projectCode, Pageable pageable);
 	// List<HistoryDto> getHistoryList(String teamCode, String projectCode,;
 	//
 	// Page<HistoryDto> getOffsetPageHistoryList(String teamCode, String projectCode, Pageable page);

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
@@ -14,5 +14,6 @@ public interface ScanHistoryRepository extends JpaRepository<ScanHistory, Long> 
 	Optional<ScanHistory> findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(String teamCode,
 		String projectCode, String hashCode);
 
-	Page<ScanHistory> findAllbyTeam_TeamCodeAndProject_ProjectCode(Pageable pageable, String teamCode, String projectCode);
+	Page<ScanHistory> findAllByTeam_TeamCodeAndProject_ProjectCode(Pageable pageable, String teamCode,
+		String projectCode);
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/infra/repository/ScanHistoryRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface ScanHistoryRepository extends JpaRepository<ScanHistory, Long> {
 	Optional<ScanHistory> findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(String teamCode,
 		String projectCode, String hashCode);
+
+	Page<ScanHistory> findAllbyTeam_TeamCodeAndProject_ProjectCode(Pageable pageable, String teamCode, String projectCode);
 }


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #48

## Update Summary
- 단일 스캔 이력에 관환 페이지 기능 구현

## New/Edited policies
- 페이지 처리 데이터는 ScanHistory에서 파일이름, passed, failed, skipped 정보를 보여준다.
- query parameters로 page, size, sort에 대한 정보를 전달한다.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [x] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [x] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.