### PR TITLE
[IC-83] feat: 단일 스캔 이력 조회(전체 내역 조회)

### DIFF
--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -34,6 +34,16 @@ public class ScanHistoryController {
 	}
 
 	/*
+		단일 스캔 전체 내역 조회
+	 */
+	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history/{hashCode}/total")
+	public ResponseDto<ScanResultDto> getScanHistoryTotal(@PathVariable("teamCode") String teamCode,
+		@PathVariable("projectCode") String projectCode, @PathVariable("hashCode") String hashCode) {
+		ScanResultDto dto = scanHistoryService.getScanHistoryTotal(teamCode, projectCode, hashCode);
+		return new ResponseDto<>(dto);
+	}
+
+	/*
 		단일 스캔 이력 Pagination
 	 */
 	@GetMapping("/{teamCode}/projects/{projectCode}/scans/history")

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/HistoryDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/HistoryDto.java
@@ -1,6 +1,7 @@
 package com.initcloud.rocket23.checklist.dto;
 
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,27 +12,25 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HistoryDto {
-    private Long id;
-    private String fileName;
-    private String fileHash;
-    private String provider;
-    private LocalDateTime scanDateTime;
-    private Double score;
-    private Integer failed;
-    private Integer passed;
-    private Integer skipped;
+	private Long id;
+	private String fileName;
+	private String fileHash;
+	private LocalDateTime scanDateTime;
+	private Double score;
+	private Integer failed;
+	private Integer passed;
+	private Integer skipped;
 
-    public HistoryDto(ScanHistory entity) {
-        this.id = entity.getId();
-        this.fileName = entity.getFileName();
-        this.fileHash = entity.getFileHash();
-        this.scanDateTime = entity.getCreatedAt();
-        this.provider = entity.getCsp();
-        this.score = entity.getScore();
-        this.failed = entity.getFailed();
-        this.passed = entity.getPassed();
-        this.skipped = entity.getSkipped();
-    }
+	public HistoryDto(ScanHistory entity) {
+		this.id = entity.getId();
+		this.fileName = entity.getFileName();
+		this.fileHash = entity.getFileHash();
+		this.scanDateTime = entity.getCreatedAt();
+		this.score = entity.getScore();
+		this.failed = entity.getFailed();
+		this.passed = entity.getPassed();
+		this.skipped = entity.getSkipped();
+	}
 
 	@Builder
 	public HistoryDto(Long id, String fileName, String fileHash, String provider, LocalDateTime scanDateTime,
@@ -39,7 +38,6 @@ public class HistoryDto {
 		this.id = id;
 		this.fileName = fileName;
 		this.fileHash = fileHash;
-		this.provider = provider;
 		this.scanDateTime = scanDateTime;
 		this.score = score;
 		this.failed = failed;

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanFailDetailDto.java
@@ -18,7 +18,7 @@ public class ScanFailDetailDto {
 	private int low;
 	private int medium;
 	private int unknown;
-	private List<FailResource> failResourceList;
+	private List<FailResource> failResourceList = new ArrayList<>();
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -39,7 +39,6 @@ public class ScanFailDetailDto {
 		this.low = scanHistory.getLow();
 		this.medium = scanHistory.getMedium();
 		this.unknown = scanHistory.getUnknown();
-		this.failResourceList = new ArrayList<>();
 		failResourceList.addAll(scanHistoryDetails.stream()
 			.map(detail -> new FailResource(detail.getRuleName(), detail.getResource(), detail.getResourceName()))
 			.collect(Collectors.toList()));

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
@@ -1,5 +1,6 @@
 package com.initcloud.rocket23.checklist.dto;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ public class ScanResultDto {
 	private Integer passed;
 	private Integer failed;
 	private Integer skipped;
+	private LocalDateTime created;
 	private List<Detail> scanResultDetailList = new ArrayList<>();
 
 	@Builder
@@ -37,6 +39,7 @@ public class ScanResultDto {
 		this.passed = scanHistory.getPassed();
 		this.failed = scanHistory.getFailed();
 		this.skipped = scanHistory.getSkipped();
+		this.created = scanHistory.getCreatedAt();
 		//todo 좀더 이쁘게 dto를 처리하는 방법...
 		if (scanHistoryDetails != null) {
 			this.scanResultDetailList.addAll(scanHistoryDetails.stream()

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/dto/ScanResultDto.java
@@ -1,8 +1,14 @@
 package com.initcloud.rocket23.checklist.dto;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.initcloud.rocket23.checklist.entity.ScanHistory;
+import com.initcloud.rocket23.checklist.entity.ScanHistoryDetail;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,17 +24,51 @@ public class ScanResultDto {
 	private Integer passed;
 	private Integer failed;
 	private Integer skipped;
+	private List<Detail> scanResultDetailList = new ArrayList<>();
 
-	public ScanResultDto(ScanHistory entity) {
-		this.fileName = entity.getFileName();
-		this.high = entity.getHigh();
-		this.medium = entity.getMedium();
-		this.low = entity.getLow();
-		this.unknown = entity.getUnknown();
-		this.score = entity.getScore();
-		this.passed = entity.getPassed();
-		this.failed = entity.getFailed();
-		this.skipped = entity.getSkipped();
+	@Builder
+	public ScanResultDto(ScanHistory scanHistory, List<ScanHistoryDetail> scanHistoryDetails) {
+		this.fileName = scanHistory.getFileName();
+		this.high = scanHistory.getHigh();
+		this.medium = scanHistory.getMedium();
+		this.low = scanHistory.getLow();
+		this.unknown = scanHistory.getUnknown();
+		this.score = scanHistory.getScore();
+		this.passed = scanHistory.getPassed();
+		this.failed = scanHistory.getFailed();
+		this.skipped = scanHistory.getSkipped();
+		//todo 좀더 이쁘게 dto를 처리하는 방법...
+		if (scanHistoryDetails != null) {
+			this.scanResultDetailList.addAll(scanHistoryDetails.stream()
+				.map(Detail::new)
+				.collect(Collectors.toList()));
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class Detail {
+		private String checkType;
+		private String appType;
+		private String scanResult;
+		private String csp;
+		private String line;
+		private String code;
+		private String ruleName;
+		private String resource;
+		private String resourceName;
+
+		public Detail(ScanHistoryDetail scanHistoryDetail) {
+			this.checkType = scanHistoryDetail.getCheckType();
+			this.appType = scanHistoryDetail.getAppType();
+			this.scanResult = scanHistoryDetail.getScanResult();
+			this.csp = scanHistoryDetail.getCsp();
+			this.line = scanHistoryDetail.getLine();
+			this.code = scanHistoryDetail.getCode();
+			this.ruleName = scanHistoryDetail.getRuleName();
+			this.resource = scanHistoryDetail.getResource();
+			this.resourceName = scanHistoryDetail.getResourceName();
+		}
 	}
 
 	@Getter

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistory.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistory.java
@@ -22,89 +22,86 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ScanHistory extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "HISTORY_ID")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "HISTORY_ID")
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "TEAM_ID")
-    private Team team;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID")
+	private Team team;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PROJECT_ID")
-    private TeamProject project;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "PROJECT_ID")
+	private TeamProject project;
 
-    @Column(name = "FILE_NAME")
-    @NotNull
-    private String fileName;
+	@Column(name = "FILE_NAME")
+	@NotNull
+	private String fileName;
 
-    @Column(name = "FILE_HASH")
-    @NotNull
-    private String fileHash;
+	@Column(name = "FILE_HASH")
+	@NotNull
+	private String fileHash;
 
-    @Column(name = "PASSED")
-    @NotNull
-    private Integer passed;
+	@Column(name = "PASSED")
+	@NotNull
+	private Integer passed;
 
-    @Column(name = "SKIPPED")
-    @NotNull
-    private Integer skipped;
+	@Column(name = "SKIPPED")
+	@NotNull
+	private Integer skipped;
 
-    @Column(name = "FAILED")
-    @NotNull
-    private Integer failed;
+	@Column(name = "FAILED")
+	@NotNull
+	private Integer failed;
 
-    @Column(name = "HIGH")
-    @NotNull
-    private Integer high;
+	@Column(name = "HIGH")
+	@NotNull
+	private Integer high;
 
-    @Column(name = "MEDIUM")
-    @NotNull
-    private Integer medium;
+	@Column(name = "MEDIUM")
+	@NotNull
+	private Integer medium;
 
-    @Column(name = "LOW")
-    @NotNull
-    private Integer low;
+	@Column(name = "LOW")
+	@NotNull
+	private Integer low;
 
-    @Column(name = "UNKNOWN")
-    @NotNull
-    private Integer unknown;
+	@Column(name = "UNKNOWN")
+	@NotNull
+	private Integer unknown;
 
-    @Column(name = "CVE_COUNT")
-    @NotNull
-    private Integer cveCount;
+	@Column(name = "CVE_COUNT")
+	@NotNull
+	private Integer cveCount;
 
-    @Column(name = "SCORE")
-    @NotNull
-    private Double score;
+	@Column(name = "SCORE")
+	@NotNull
+	private Double score;
 
-    @Column(name = "CSP")
-    @NotNull
-    @Size(max = 16)
-    private String csp;
+	@OneToMany(mappedBy = "scanHistory")
+	private List<ScanHistoryDetail> scanDetails = new ArrayList<>();
 
-    @OneToMany(mappedBy = "scanHistory")
-    private List<ScanHistoryDetail> scanDetails = new ArrayList<>();
+	@OneToMany(mappedBy = "scanHistory")
+	private List<ProjectVulnDetail> fileDetails = new ArrayList<>();
 
-    @OneToMany(mappedBy = "scanHistory")
-    private List<ProjectVulnDetail> fileDetails = new ArrayList<>();
-
-    @Builder
-    public ScanHistory(Long id, Team team, TeamProject project, String fileName, String fileHash, Integer passed, Integer skipped, Integer failed, Integer high, Integer medium, Integer low, Integer unknown, Integer cveCount, Double score) {
-        this.id = id;
-        this.team = team;
-        this.project = project;
-        this.fileName = fileName;
-        this.fileHash = fileHash;
-        this.passed = passed;
-        this.skipped = skipped;
-        this.failed = failed;
-        this.high = high;
-        this.medium = medium;
-        this.low = low;
-        this.unknown = unknown;
-        this.cveCount = cveCount;
-        this.score = score;
-    }
+	@Builder
+	public ScanHistory(Long id, Team team, TeamProject project, String fileName, String fileHash, Integer passed,
+		Integer skipped, Integer failed, Integer high, Integer medium, Integer low, Integer unknown, Integer cveCount,
+		Double score) {
+		this.id = id;
+		this.team = team;
+		this.project = project;
+		this.fileName = fileName;
+		this.fileHash = fileHash;
+		this.passed = passed;
+		this.skipped = skipped;
+		this.failed = failed;
+		this.high = high;
+		this.medium = medium;
+		this.low = low;
+		this.unknown = unknown;
+		this.cveCount = cveCount;
+		this.score = score;
+	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistoryDetail.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/entity/ScanHistoryDetail.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import com.initcloud.rocket23.common.entity.BaseEntity;
 
@@ -61,9 +62,15 @@ public class ScanHistoryDetail extends BaseEntity {
 	@NotNull
 	private String ruleName;
 
+	@Column(name = "CSP")
+	@NotNull
+	@Size(max = 16)
+	private String csp;
+
 	@Builder
 	public ScanHistoryDetail(ScanHistory scanHistory, String checkType,
-		String targetFileName, String appType, String scanResult, String line, String code, String resource, String resourceName,String ruleName) {
+		String targetFileName, String appType, String scanResult, String line, String code, String resource,
+		String resourceName, String ruleName, String csp) {
 		this.scanHistory = scanHistory;
 		this.checkType = checkType;
 		this.targetFileName = targetFileName;
@@ -74,6 +81,7 @@ public class ScanHistoryDetail extends BaseEntity {
 		this.resource = resource;
 		this.resourceName = resourceName;
 		this.ruleName = ruleName;
+		this.csp = csp;
 		scanHistory.getScanDetails().add(this);
 	}
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/Impl/ScanHistoryServiceImpl.java
@@ -37,7 +37,24 @@ public class ScanHistoryServiceImpl implements ScanHistoryService {
 		ScanHistory scanHistory = scanHistoryRepository.findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(
 			teamCode,
 			projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
-		return new ScanResultDto(scanHistory);
+		return ScanResultDto.builder()
+			.scanHistory(scanHistory)
+			.build();
+	}
+
+	/*
+		단일 스캔 전체 내역 조회
+	 */
+	@Override
+	public ScanResultDto getScanHistoryTotal(String teamCode, String projectCode, String hashCode) {
+		ScanHistory scanHistory = scanHistoryRepository.findTopByTeam_TeamCodeAndProject_ProjectCodeAndFileHashOrderById(
+			teamCode, projectCode, hashCode).orElseThrow(() -> new ApiException(ResponseCode.NO_SCAN_RESULT));
+		List<ScanHistoryDetail> scanHistoryDetails = scanHistory.getScanDetails();
+
+		return ScanResultDto.builder()
+			.scanHistory(scanHistory)
+			.scanHistoryDetails(scanHistoryDetails)
+			.build();
 	}
 
 	/*

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/service/ScanHistoryService.java
@@ -13,9 +13,11 @@ import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 public interface ScanHistoryService {
 	ScanResultDto getScanHistory(String teamCode, String projectCode, String fileHash);
 
+	ScanResultDto getScanHistoryTotal(String teamCode, String projectCode, String fileHash);
+
 	ScanFailDetailDto getScanFailDetail(String teamCode, String projectCode, String fileHash);
 
-	Page<ScanResultDto.Summary>	getScanHistoryPaging(String teamCode, String projectCode, Pageable pageable);
+	Page<ScanResultDto.Summary> getScanHistoryPaging(String teamCode, String projectCode, Pageable pageable);
 	// List<HistoryDto> getHistoryList(String teamCode, String projectCode,;
 	//
 	// Page<HistoryDto> getOffsetPageHistoryList(String teamCode, String projectCode, Pageable page);


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
* Feature #50

## Update Summary
1. 단일 스캔 이력에서 전체 내역 조회 개발 Dto, controller, service
2. ERD 수정에 따른 Entity 수정

## New/Edited policies
1. 전채 내역 조회를 위한 ScanResultDto에 nested class로 Detail을 생성 및 creadted_at 맴버 변수 추가
2. ERD에서 ScanHistory의 CSP가 ScanHistoryDetail의 필드로 변경, 이를 반영하기 위해 Entity의 CSP 맴버변수 수정
3. ScanResultDto 생성자를 Builder 형식으로 변경 -> 필요한 데이터에 따라 생성자를 정의하기 위해서

## Unresolved Issue
ScanResultDto의 생성자에서 `scanHistoryDetail`의 null 확인을 유연하게 할 수 없을까 고민중.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [x] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.