### PR TITLE
[IC-107] hotfix: swagger에서 사용하는 spring-fox를 spring-docs로 대체

### DIFF
--- a/scanhistory/build.gradle
+++ b/scanhistory/build.gradle
@@ -59,13 +59,16 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.33'
 
     // https://mvnrepository.com/artifact/io.springfox/springfox-boot-starter
-    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    //implementation 'io.springfox:springfox-boot-starter:3.0.0'
 
     // https://mvnrepository.com/artifact/io.springfox/springfox-swagger2
-    implementation 'io.springfox:springfox-swagger2:3.0.0'
+    //implementation 'io.springfox:springfox-swagger2:3.0.0'
 
     // https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
-    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+    //implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
+    implementation 'org.springdoc:springdoc-openapi-ui:1.5.7'
 }
 
 tasks.named('test') {

--- a/scanhistory/build.gradle
+++ b/scanhistory/build.gradle
@@ -58,17 +58,8 @@ dependencies {
     // https://mvnrepository.com/artifact/mysql/mysql-connector-java
     implementation 'mysql:mysql-connector-java:8.0.33'
 
-    // https://mvnrepository.com/artifact/io.springfox/springfox-boot-starter
-    //implementation 'io.springfox:springfox-boot-starter:3.0.0'
-
-    // https://mvnrepository.com/artifact/io.springfox/springfox-swagger2
-    //implementation 'io.springfox:springfox-swagger2:3.0.0'
-
-    // https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
-    //implementation 'io.springfox:springfox-swagger-ui:3.0.0'
-
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
-    implementation 'org.springdoc:springdoc-openapi-ui:1.5.7'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 }
 
 tasks.named('test') {

--- a/scanhistory/src/main/java/com/initcloud/rocket23/ScanhistoryApplication.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/ScanhistoryApplication.java
@@ -5,10 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import springfox.documentation.oas.annotations.EnableOpenApi;
 
 @EnableWebMvc
-@EnableOpenApi
 @EnableFeignClients(basePackages = {"com.initcloud.rocket23.common.feign"})
 @EnableJpaAuditing
 @SpringBootApplication

--- a/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/checklist/controller/ScanHistoryController.java
@@ -4,12 +4,15 @@ import com.initcloud.rocket23.checklist.dto.ScanFailDetailDto;
 import com.initcloud.rocket23.checklist.dto.ScanResultDto;
 import com.initcloud.rocket23.checklist.service.ScanHistoryService;
 import com.initcloud.rocket23.common.dto.ResponseDto;
-
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,116 +20,124 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@ApiOperation("Scan History API")
+@Tag(name = "Scan History API")
 @RestController
 @RequestMapping("/rocket/team/")
 @RequiredArgsConstructor
 public class ScanHistoryController {
 
-	private final ScanHistoryService scanHistoryService;
+    private final ScanHistoryService scanHistoryService;
 
-	/*
-		단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
-	 */
-	@ApiOperation(value = "Get a scan-history", notes = "Retrieve a scan-history.", response = ResponseDto.class)
-	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "projectCode", paramType = "path", value = "Project unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "hashCode", paramType = "path", value = "History unique code", required = true, dataTypeClass = String.class)})
-	@GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}")
-	public ResponseDto<ScanResultDto> getScanHistory(
-			@PathVariable("teamCode") String teamCode,
-			@PathVariable("projectCode") String projectCode,
-			@PathVariable("hashCode") String hashCode
-	) {
-		ScanResultDto dto = scanHistoryService.getScanHistory(teamCode, projectCode, hashCode);
-		return new ResponseDto<>(dto);
-	}
+    /*
+        단일 스캔 이력 조회(검출통계[성공, 실패, 스킵, 전체스캔])
+     */
+    @Operation(summary = "Get a scan-history", description = "Retrieve a scan-history.", responses = {
+            @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "projectCode", in = ParameterIn.PATH, description = "Project unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "hashCode", in = ParameterIn.PATH, description = "History unique code", required = true, schema = @Schema(type = "string"))
+    @GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}")
+    public ResponseDto<ScanResultDto> getScanHistory(
+            @PathVariable("teamCode") String teamCode,
+            @PathVariable("projectCode") String projectCode,
+            @PathVariable("hashCode") String hashCode
+    ) {
+        ScanResultDto dto = scanHistoryService.getScanHistory(teamCode, projectCode, hashCode);
+        return new ResponseDto<>(dto);
+    }
 
-	/*
-		단일 스캔 전체 내역 조회
-	 */
-	@GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}/total")
-	public ResponseDto<ScanResultDto> getScanHistoryTotal(
-			@PathVariable("teamCode") String teamCode,
-			@PathVariable("projectCode") String projectCode,
-			@PathVariable("hashCode") String hashCode
-	) {
-		ScanResultDto dto = scanHistoryService.getScanHistoryTotal(teamCode, projectCode, hashCode);
-		return new ResponseDto<>(dto);
-	}
+    /*
+        단일 스캔 전체 내역 조회
+     */
+    @GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}/total")
+    public ResponseDto<ScanResultDto> getScanHistoryTotal(
+            @PathVariable("teamCode") String teamCode,
+            @PathVariable("projectCode") String projectCode,
+            @PathVariable("hashCode") String hashCode
+    ) {
+        ScanResultDto dto = scanHistoryService.getScanHistoryTotal(teamCode, projectCode, hashCode);
+        return new ResponseDto<>(dto);
+    }
 
-	/*
-		단일 스캔 이력 Pagination
-	 */
-	@ApiOperation(value = "Get paged scan-history list", notes = "Retrieve paged scan-history list.", response = ResponseDto.class)
-	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "projectCode", paramType = "path", value = "Project unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "pageable", paramType = "query", value = "paging value", required = true, dataTypeClass = Pageable.class)})
-	@GetMapping("/{teamCode}/projects/{projectCode}/history")
-	public ResponseDto<Page<ScanResultDto.Summary>> getScanHistoryPaging(
-			@PathVariable("teamCode") String teamCode,
-			@PathVariable("projectCode") String projectCode,
-			final Pageable pageable
-	) {
-		Page<ScanResultDto.Summary> dtos = scanHistoryService.getScanHistoryPaging(teamCode, projectCode, pageable);
-		return new ResponseDto<>(dtos);
-	}
+    /*
+        단일 스캔 이력 Pagination
+     */
+    @Operation(summary = "Get paged scan-history list",
+            description = "Retrieve paged scan-history list.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "projectCode", in = ParameterIn.PATH, description = "Project unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "pageable", in = ParameterIn.QUERY, description = "paging value", required = true, content = @Content(schema = @Schema(implementation = PageableAsQueryParam.class)))
+    @GetMapping("/{teamCode}/projects/{projectCode}/history")
+    public ResponseDto<Page<ScanResultDto.Summary>> getScanHistoryPaging(
+            @PathVariable("teamCode") String teamCode,
+            @PathVariable("projectCode") String projectCode,
+            final Pageable pageable
+    ) {
+        Page<ScanResultDto.Summary> dtos = scanHistoryService.getScanHistoryPaging(teamCode, projectCode, pageable);
+        return new ResponseDto<>(dtos);
+    }
 
-	/*
-		단일 스캔 실패 내역에 대한 조회
-	 */
-	@ApiOperation(value = "Get a failed-scan-history", notes = "Retrieve a failed-scan-history.", response = ResponseDto.class)
-	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "projectCode", paramType = "path", value = "Project unique code", required = true, dataTypeClass = String.class),
-			@ApiImplicitParam(name = "hashCode", paramType = "path", value = "History unique code", required = true, dataTypeClass = String.class)})
-	@GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}/fail")
-	public ResponseDto<ScanFailDetailDto> getScanFailDetail(
-			@PathVariable("teamCode") String teamCode,
-			@PathVariable("projectCode") String projectCode,
-			@PathVariable("hashCode") String hashCode
-	) {
-		ScanFailDetailDto dtos = scanHistoryService.getScanFailDetail(teamCode, projectCode, hashCode);
-		return new ResponseDto<>(dtos);
-	}
+    /*
+        단일 스캔 실패 내역에 대한 조회
+     */
+    @Operation(
+            summary = "Get a failed-scan-history",
+            description = "Retrieve a failed-scan-history.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "projectCode", in = ParameterIn.PATH, description = "Project unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "hashCode", in = ParameterIn.PATH, description = "History unique code", required = true, schema = @Schema(type = "string"))
+    @GetMapping("/{teamCode}/projects/{projectCode}/history/{hashCode}/fail")
+    public ResponseDto<ScanFailDetailDto> getScanFailDetail(
+            @PathVariable("teamCode") String teamCode,
+            @PathVariable("projectCode") String projectCode,
+            @PathVariable("hashCode") String hashCode
+    ) {
+        ScanFailDetailDto dtos = scanHistoryService.getScanFailDetail(teamCode, projectCode, hashCode);
+        return new ResponseDto<>(dtos);
+    }
 
-	/**
-	 * get 방식을 통해 file scan history 내역을 최근 10개를 출력하도록함.
-	 *
-	 */
-	//	@GetMapping("/{team}/projects/{project}/scans/recent")
-	//	public ResponseDto<List<HistoryDto>> getHistoryList(@PathVariable("team") Long teamId,
-	//		@PathVariable("project") Long projectId) {
-	//		List<HistoryDto> dtos = scanHistoryService.getHistoryList(teamId, projectId);
-	//		return new ResponseDto<>(dtos);
-	//	}
-	//
-	//	@GetMapping("/{team}/projects/{project}/scans")
-	//	public ResponseDto<Page<HistoryDto>> getOffsetPageHistoryList(@PathVariable("team") Long teamId,
-	//		@PathVariable("project") Long projectId,
-	//		@RequestParam(required = true) Integer page) {
-	//		PageRequest pageRequest = PageRequest.of(page, 10, Sort.Direction.DESC, "historyId");
-	//		Page<HistoryDto> dtos = scanHistoryService.getOffsetPageHistoryList(teamId, projectId, pageRequest);
-	//		return new ResponseDto<>(dtos);
-	//	}
-	//
-	//    /**
-	//     * get 방식을 통해 url로 file의 uuid값을 전달받음
-	//     *
-	//     * @param fileHash path를 통해 전달받은 file의 uuid값
-	//     * @return file에 해당하는 스캔내역
-	//	 * get 방식을 통한 file pagination 기능 구현 teamId 와 historyseq를 통한 cursor 지정.
-	//	*/
-	//     @GetMapping("/{team}/projects/{project}/scans/cursor")
-	//	public ResponseDto<CursorResultDto> getCursorPageHistoryList(@PathVariable("team") Long teamId,
-	//		@RequestParam(required = false) Long cursorId) {
-	//		CursorResultDto dtos;
-	//		dtos = scanHistoryService.getCursorPageHistoryList(teamId, cursorId, PageRequest.of(0, 10));
-	//        return new ResponseDto<>(dtos);
-	//    }
+    /**
+     * get 방식을 통해 file scan history 내역을 최근 10개를 출력하도록함.
+     *
+     */
+    //	@GetMapping("/{team}/projects/{project}/scans/recent")
+    //	public ResponseDto<List<HistoryDto>> getHistoryList(@PathVariable("team") Long teamId,
+    //		@PathVariable("project") Long projectId) {
+    //		List<HistoryDto> dtos = scanHistoryService.getHistoryList(teamId, projectId);
+    //		return new ResponseDto<>(dtos);
+    //	}
+    //
+    //	@GetMapping("/{team}/projects/{project}/scans")
+    //	public ResponseDto<Page<HistoryDto>> getOffsetPageHistoryList(@PathVariable("team") Long teamId,
+    //		@PathVariable("project") Long projectId,
+    //		@RequestParam(required = true) Integer page) {
+    //		PageRequest pageRequest = PageRequest.of(page, 10, Sort.Direction.DESC, "historyId");
+    //		Page<HistoryDto> dtos = scanHistoryService.getOffsetPageHistoryList(teamId, projectId, pageRequest);
+    //		return new ResponseDto<>(dtos);
+    //	}
+    //
+    //    /**
+    //     * get 방식을 통해 url로 file의 uuid값을 전달받음
+    //     *
+    //     * @param fileHash path를 통해 전달받은 file의 uuid값
+    //     * @return file에 해당하는 스캔내역
+    //	 * get 방식을 통한 file pagination 기능 구현 teamId 와 historyseq를 통한 cursor 지정.
+    //	*/
+    //     @GetMapping("/{team}/projects/{project}/scans/cursor")
+    //	public ResponseDto<CursorResultDto> getCursorPageHistoryList(@PathVariable("team") Long teamId,
+    //		@RequestParam(required = false) Long cursorId) {
+    //		CursorResultDto dtos;
+    //		dtos = scanHistoryService.getCursorPageHistoryList(teamId, cursorId, PageRequest.of(0, 10));
+    //        return new ResponseDto<>(dtos);
+    //    }
 }

--- a/scanhistory/src/main/java/com/initcloud/rocket23/policy/controller/PolicyController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/policy/controller/PolicyController.java
@@ -5,17 +5,27 @@ import com.initcloud.rocket23.policy.dto.PolicyCreateDto;
 import com.initcloud.rocket23.policy.dto.PolicyDto;
 import com.initcloud.rocket23.policy.dto.PolicySetDto;
 import com.initcloud.rocket23.policy.service.PolicyService;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-@ApiOperation("Team Policy and Policy-set API")
+@Tag(name = "Team Policy and Policy-set API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rocket/team")
@@ -27,37 +37,52 @@ public class PolicyController {
      * ===== Team Policy =====
      */
 
-    @ApiOperation(value = "Get paged policies", notes = "Retrieve paged policies.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get paged policies",
+            description = "Retrieve paged policies.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/policies")
     public ResponseDto<Page<PolicyDto.Summary>> teamPagedPolicies( // Todo 어떻게 표현할건지?
-            final Pageable pageable,
-            @PathVariable String teamCode
+                                                                   final Pageable pageable,
+                                                                   @PathVariable String teamCode
     ) {
         Page<PolicyDto.Summary> response = policyService.getPagedTeamPolicyList(pageable, teamCode);
 
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Get all policies", notes = "Retrieve all policies.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get all policies",
+            description = "Retrieve all policies.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/policies/all")
     public ResponseDto<List<PolicyDto.Summary>> teamPolicies( // Todo 어떻게 표현할건지?
-            @PathVariable String teamCode
+                                                              @PathVariable String teamCode
     ) {
         List<PolicyDto.Summary> response = policyService.getTeamPolicyList(teamCode);
 
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Add a policy", notes = "Add a policy.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Add a policy",
+            description = "Add a policy.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @PostMapping("/{teamCode}/policies")
     public ResponseDto<String> teamPolicyAdd(
             @PathVariable String teamCode,
@@ -68,11 +93,16 @@ public class PolicyController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Get policy details", notes = "Retrieve a policy.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policyName", paramType = "path", value = "Unique policy name", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get policy details",
+            description = "Retrieve a policy.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policyName", in = ParameterIn.PATH, description = "Unique policy name", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/policies/{policyName}")
     public ResponseDto<PolicyDto.Details> teamPolicyDetails(
             @PathVariable String teamCode,
@@ -83,28 +113,38 @@ public class PolicyController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Modify a policy", notes = "Modify policy details.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policyName", paramType = "path", value = "Unique policy name", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "dto", paramType = "body", value = "Policy details", required = true, dataTypeClass = PolicyCreateDto.class)})
+    @Operation(
+            summary = "Modify a policy",
+            description = "Modify policy details.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policyName", in = ParameterIn.PATH, description = "Unique policy name", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = PolicyCreateDto.class)), description = "Policy details", required = true)
     @PutMapping("/{teamCode}/policies/{policyName}")
     public ResponseDto<String> teamPolicyModify(
             @PathVariable String teamCode,
             @PathVariable String policyName,
-            @RequestBody PolicyCreateDto dto
+            @org.springframework.web.bind.annotation.RequestBody PolicyCreateDto dto
     ) {
         String response = policyService.modifyTeamPolicy(teamCode, policyName, dto);
 
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Remove a policy", notes = "Remove a policy.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policyName", paramType = "path", value = "Unique policy name", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Remove a policy",
+            description = "Remove a policy.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policyName", in = ParameterIn.PATH, description = "Unique policy name", required = true, schema = @Schema(type = "string"))
     @DeleteMapping("/{teamCode}/policies/{policyName}")
     public ResponseDto<String> teamPolicyRemove(
             @PathVariable String teamCode,
@@ -119,10 +159,15 @@ public class PolicyController {
      * ===== Team PolicySet =====
      */
 
-    @ApiOperation(value = "Get policy-set List", notes = "Show policy-set List.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get policy-set List",
+            description = "Show policy-set List.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/policysets")
     public ResponseDto<List<String>> policySetList(
             @PathVariable String teamCode
@@ -132,11 +177,16 @@ public class PolicyController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Get policy-set", notes = "Show policy-set.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policyset", paramType = "path", value = "policy-set code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get policy-set",
+            description = "Show policy-set.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policyset", in = ParameterIn.PATH, description = "policy-set code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/policysets/{policyset}")
     public ResponseDto<PolicySetDto> policySetDetails(
             @PathVariable String teamCode,
@@ -148,11 +198,16 @@ public class PolicyController {
     }
 
 
-    @ApiOperation(value = "Add a policy set", notes = "Add a policy set.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "request", paramType = "body", value = "Policy-set-add info.", required = true, dataTypeClass = PolicySetDto.class)})
+    @Operation(
+            summary = "Add a policy set",
+            description = "Add a policy set.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = PolicySetDto.class)), description = "Policy-set-add info.", required = true)
     @PostMapping("/{teamCode}/policysets")
     public ResponseDto<String> policySetAdd(
             @PathVariable String teamCode,
@@ -163,12 +218,16 @@ public class PolicyController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Modify a policy set", notes = "Modify a policy set.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policySet", paramType = "path", value = "Unique policy set name", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "request", paramType = "body", value = "Policy-set-modify info.", required = true, dataTypeClass = PolicySetDto.class)})
+    @Operation(
+            summary = "Modify a policy set",
+            description = "Modify a policy set.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policySet", in = ParameterIn.PATH, description = "Unique policy set name", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = PolicySetDto.class)), description = "Policy-set-modify info.", required = true)
     @PutMapping("/{teamCode}/policysets/{policySet}")
     public ResponseDto<String> policySetModify(
             @PathVariable String teamCode,
@@ -180,11 +239,15 @@ public class PolicyController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Remove a policy set", notes = "Remove a policy set.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "policySet", paramType = "path", value = "Unique policy set name", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Remove a policy set",
+            description = "Remove a policy set.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "policySet", in = ParameterIn.PATH, description = "Unique policy set name", required = true, schema = @Schema(type = "string"))
     @DeleteMapping("/{teamCode}/policysets/{policySet}")
     public ResponseDto policySetRemove(
             @PathVariable String teamCode,

--- a/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityConfig.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/security/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/v2/api-docs/**").permitAll()
+                .antMatchers("/api-docs/**").permitAll()
                 .antMatchers("/swagger-resources/**").permitAll()
                 .antMatchers("/swagger-ui/**").permitAll()
                 .and()

--- a/scanhistory/src/main/java/com/initcloud/rocket23/swagger/SwaggerConfig.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/swagger/SwaggerConfig.java
@@ -1,51 +1,51 @@
-package com.initcloud.rocket23.swagger;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
-
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-@Configuration
-@EnableSwagger2
-@EnableAsync
-@EnableWebMvc
-public class SwaggerConfig extends WebMvcConfigurationSupport {
-
-    private static final String API_NAME = "Init Cloud Rocket";
-    private static final String API_VERSION = "0.1";
-    private static final String API_DESCRIPTION = "Rocket Main API Description";
-
-    @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
-                .select()
-                .apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.ant("/**"))
-                .build();
-    }
-
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder()
-                .title(API_NAME)
-                .version(API_VERSION)
-                .description(API_DESCRIPTION)
-                .build();
-    }
-
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
-    }
-}
+//package com.initcloud.rocket23.swagger;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//import org.springframework.scheduling.annotation.EnableAsync;
+//import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+//import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+//
+//import springfox.documentation.builders.ApiInfoBuilder;
+//import springfox.documentation.builders.PathSelectors;
+//import springfox.documentation.builders.RequestHandlerSelectors;
+//import springfox.documentation.service.ApiInfo;
+//import springfox.documentation.spi.DocumentationType;
+//import springfox.documentation.spring.web.plugins.Docket;
+//import springfox.documentation.swagger2.annotations.EnableSwagger2;
+//
+//@Configuration
+//@EnableSwagger2
+//@EnableAsync
+//@EnableWebMvc
+//public class SwaggerConfig extends WebMvcConfigurationSupport {
+//
+//    private static final String API_NAME = "Init Cloud Rocket";
+//    private static final String API_VERSION = "0.1";
+//    private static final String API_DESCRIPTION = "Rocket Main API Description";
+//
+//    @Bean
+//    public Docket api() {
+//        return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
+//                .select()
+//                .apis(RequestHandlerSelectors.any())
+//                .paths(PathSelectors.ant("/**"))
+//                .build();
+//    }
+//
+//    private ApiInfo apiInfo() {
+//        return new ApiInfoBuilder()
+//                .title(API_NAME)
+//                .version(API_VERSION)
+//                .description(API_DESCRIPTION)
+//                .build();
+//    }
+//
+//    @Override
+//    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+//        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
+//        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+//    }
+//}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/swagger/SwaggerdocConfig.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/swagger/SwaggerdocConfig.java
@@ -1,0 +1,34 @@
+package com.initcloud.rocket23.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerdocConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Init Cloud Rocket")
+                .version("0.1")
+                .description("Rocket Main API Description");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+
+    @Bean
+    public GroupedOpenApi api() {
+        return GroupedOpenApi.builder()
+                .group("API")
+                .pathsToMatch("/**")
+                .build();
+    }
+
+
+}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamGithubProjectController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamGithubProjectController.java
@@ -3,17 +3,17 @@ package com.initcloud.rocket23.team.controller;
 import com.initcloud.rocket23.common.dto.ResponseDto;
 import com.initcloud.rocket23.team.dto.GithubRepositoryDto;
 import com.initcloud.rocket23.team.service.GithubAppService;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletResponse;
-import java.util.List;
-
-@ApiOperation("Github Apps API")
+@Tag(name = "Github Apps API")
 @RestController
 @RequestMapping("/rocket/github")
 @RequiredArgsConstructor
@@ -21,13 +21,13 @@ public class TeamGithubProjectController {
 
     private final GithubAppService appService;
 
-    @ApiOperation(value = "Redirect to Github App Register page.", notes = "Redirect to Github APP page to register App.")
+    @Operation(summary = "Redirect to Github App Register page.", description = "Redirect to Github APP page to register App.")
     @GetMapping("/apps")
     public void githubAuthRedirect(HttpServletResponse response) {
         appService.redirectGithubApp(response);
     }
 
-    @ApiOperation(value = "Github app Callback", notes = "Github app Callback.")
+    @Operation(summary = "Github app Callback", description = "Github app Callback.")
     @GetMapping("/apps/callback")
     public void githubAppsCallback() {
 

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamInspectController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamInspectController.java
@@ -1,10 +1,15 @@
 package com.initcloud.rocket23.team.controller;
 
+import com.initcloud.rocket23.common.dto.ResponseDto;
 import com.initcloud.rocket23.team.dto.TeamMemberDto;
 import com.initcloud.rocket23.team.service.TeamInspectService;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,10 +18,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.initcloud.rocket23.common.dto.ResponseDto;
 
-
-@ApiOperation("Team Inspect API")
+@Tag(name = "Team Inspect API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rocket/team")
@@ -24,11 +27,16 @@ public class TeamInspectController {
 
     private final TeamInspectService teamInspectService;
 
-    @ApiOperation(value = "Get Member List with Page", notes = "Retrieve paged list of members.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "pageable", paramType = "query", value = "paging value", required = true, dataTypeClass = Pageable.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get Member List with Page",
+            description = "Retrieve paged list of members.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "pageable", in = ParameterIn.QUERY, description = "paging value", required = true, schema = @Schema(implementation = Pageable.class))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/members")
     public ResponseDto<Page<TeamMemberDto.Summary>> memberList(
             final Pageable pageable,
@@ -39,11 +47,16 @@ public class TeamInspectController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Get Member details", notes = "Retrieve specific member details", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "memberEmail", paramType = "path", value = "member email", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get Member details",
+            description = "Retrieve specific member details",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "memberEmail", in = ParameterIn.PATH, description = "member email", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/members/{memberEmail}")
     public ResponseDto<Object> memberDetails(
             @PathVariable String teamCode,

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamManageController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamManageController.java
@@ -1,20 +1,27 @@
 package com.initcloud.rocket23.team.controller;
 
-import com.initcloud.rocket23.team.dto.TeamDto;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import org.springframework.web.bind.annotation.*;
-
 import com.initcloud.rocket23.common.dto.ResponseDto;
+import com.initcloud.rocket23.team.dto.TeamDto;
 import com.initcloud.rocket23.team.dto.TeamInviteDto;
 import com.initcloud.rocket23.team.service.TeamManageService;
-
-import lombok.RequiredArgsConstructor;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@ApiOperation("Team Manage API")
+@Tag(name = "Team Manage API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rocket/team")
@@ -29,11 +36,16 @@ public class TeamManageController {
     /**
      * 사용자 팀 초대
      */
-    @ApiOperation(value = "Invite member", notes = "Invite a member to team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "request", paramType = "body", value = "Request info", required = true, dataTypeClass = TeamInviteDto.Request.class)})
+    @Operation(
+            summary = "Invite member",
+            description = "Invite a member to team.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = TeamInviteDto.Request.class)), description = "Request info", required = true)
     @PostMapping("/{teamCode}/members")
     public ResponseDto<String> memberInvite(
             @PathVariable String teamCode,
@@ -47,11 +59,16 @@ public class TeamManageController {
     /**
      * 멤버 사용자 상태 변경
      */
-    @ApiOperation(value = "Modify member details", notes = "Modify a member details", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "memberEmail", paramType = "path", value = "member email", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Modify member details",
+            description = "Modify a member details",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "memberEmail", in = ParameterIn.PATH, description = "member email", required = true, schema = @Schema(type = "string"))
     @PutMapping("/{teamCode}/members/{memberEmail}")
     public ResponseDto<Object> memberStatus(
             @PathVariable String teamCode,
@@ -64,11 +81,16 @@ public class TeamManageController {
     /**
      * 멤버 사용자 제거
      */
-    @ApiOperation(value = "Remove team member", notes = "Remove a member from team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "memberEmail", paramType = "path", value = "member email", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Remove team member",
+            description = "Remove a member from team",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "memberEmail", in = ParameterIn.PATH, description = "member email", required = true, schema = @Schema(type = "string"))
     @DeleteMapping("/{teamCode}/members/{memberEmail}")
     public ResponseDto<Object> memberRemove(
             @PathVariable String teamCode,
@@ -86,10 +108,15 @@ public class TeamManageController {
     /**
      * 팀 생성
      */
-    @ApiOperation(value = "Create team", notes = "Create a team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "request", paramType = "body", value = "Team Create Dto", required = true, dataTypeClass = TeamDto.class)})
+    @Operation(
+            summary = "Create team",
+            description = "Create a team",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = TeamDto.class)), description = "Team Create Dto", required = true)
     @PostMapping("/")
     public ResponseDto<String> teamCreate(
             @RequestBody TeamDto request
@@ -102,10 +129,15 @@ public class TeamManageController {
     /**
      * 팀 해체
      */
-    @ApiOperation(value = "Remove team", notes = "Remove a team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Remove team",
+            description = "Remove a team",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @DeleteMapping("/{teamCode}")
     public ResponseDto<Object> teamRemove(
             @PathVariable String teamCode

--- a/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamProjectController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/team/controller/TeamProjectController.java
@@ -1,21 +1,29 @@
 package com.initcloud.rocket23.team.controller;
 
+import com.initcloud.rocket23.common.dto.ResponseDto;
 import com.initcloud.rocket23.team.dto.TeamProjectCreateDto;
 import com.initcloud.rocket23.team.dto.TeamProjectDto;
 import com.initcloud.rocket23.team.service.TeamProjectService;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import com.initcloud.rocket23.common.dto.ResponseDto;
-
-import java.util.List;
-
-@ApiOperation("Team Project API")
+@Tag(name = "Team Project API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rocket/team")
@@ -26,11 +34,15 @@ public class TeamProjectController {
     /**
      * 프로젝트 목록 조회
      */
-    @ApiOperation(value = "Get Project list with Page", notes = "Retrieve paged list of projects.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "pageable", paramType = "query", value = "paging value", required = true, dataTypeClass = Pageable.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get Project list with Page",
+            description = "Retrieve paged list of projects",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class)))}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "pageable", in = ParameterIn.QUERY, description = "paging value", required = true, schema = @Schema(implementation = Pageable.class))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/projects")
     public ResponseDto<Page<TeamProjectDto.Summary>> projectPagedList(
             final Pageable pageable,
@@ -41,10 +53,18 @@ public class TeamProjectController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Get Project list.", notes = "Retrieve all list of projects.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class)})
+    /**
+     * 프로젝트 목록 조회
+     */
+    @Operation(
+            summary = "Get Project list",
+            description = "Retrieve all list of projects",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/projects/all")
     public ResponseDto<List<TeamProjectDto.Summary>> projectList(
             @PathVariable String teamCode
@@ -55,14 +75,18 @@ public class TeamProjectController {
     }
 
     /**
-     * 프로젝트 조회
-     * 프로젝트 별 대시보드 성격을 갖게 될 것임.
+     * 프로젝트 조회 프로젝트 별 대시보드 성격을 갖게 될 것임.
      */
-    @ApiOperation(value = "Get Project details", notes = "Retrieve a project.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "projectCode", paramType = "path", value = "Project unique code", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Get Project details",
+            description = "Retrieve a project",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "projectCode", in = ParameterIn.PATH, description = "Project unique code", required = true, schema = @Schema(type = "string"))
     @GetMapping("/{teamCode}/projects/{projectCode}")
     public ResponseDto<TeamProjectDto.Details> projectDetails(
             @PathVariable String teamCode,
@@ -73,11 +97,19 @@ public class TeamProjectController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Add project", notes = "Add a project to team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "request", paramType = "body", value = "Create-Project Info", readOnly = true, dataTypeClass = TeamProjectCreateDto.class)})
+    /**
+     * 프로젝트 추가
+     */
+    @Operation(
+            summary = "Add project",
+            description = "Add a project to team",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = TeamProjectCreateDto.class)), description = "Create-Project Info", required = true)
     @PostMapping("/{teamCode}/projects")
     public ResponseDto<String> projectAdd(
             @PathVariable String teamCode,
@@ -88,11 +120,19 @@ public class TeamProjectController {
         return new ResponseDto<>(response);
     }
 
-    @ApiOperation(value = "Remove project", notes = "Remove a project from team.", response = ResponseDto.class)
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", paramType = "header", value = "Access Token", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "teamCode", paramType = "path", value = "Team unique code", required = true, dataTypeClass = String.class),
-            @ApiImplicitParam(name = "projectCode", paramType = "path", value = "Project unique code", required = true, dataTypeClass = String.class)})
+    /**
+     * 프로젝트 삭제
+     */
+    @Operation(
+            summary = "Remove project",
+            description = "Remove a project from team",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Successful response", content = @Content(schema = @Schema(implementation = ResponseDto.class))
+                    )}
+    )
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Access Token", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
+    @Parameter(name = "projectCode", in = ParameterIn.PATH, description = "Project unique code", required = true, schema = @Schema(type = "string"))
     @DeleteMapping("/{teamCode}/projects/{projectCode}")
     public ResponseDto projectRemove(
             @PathVariable String teamCode,

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/AuthController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/AuthController.java
@@ -4,15 +4,23 @@ import com.initcloud.rocket23.common.dto.ResponseDto;
 import com.initcloud.rocket23.security.dto.OAuthDto;
 import com.initcloud.rocket23.security.service.OAuthService;
 import com.initcloud.rocket23.user.dto.AuthRequestDto;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@ApiOperation("Auth (Login/Register)")
+@Tag(name = "Auth (Login/Register)")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -30,15 +38,24 @@ public class AuthController {
         return new ResponseDto<>(null);
     }
 
-    @ApiOperation(value = "Redirect to Github Login page.", notes = "Redirect to Github Login page to get an auth code.")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "redirect", paramType = "query", value = "Redirect Url for FE", required = true, dataTypeClass = String.class)})
+    @Operation(
+            summary = "Redirect to Github Login page.",
+            description = "Redirect to Github Login page to get an auth code.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Redirect response to Github Login page",
+                            content = @Content(schema = @Schema(type = "string"))
+                    )
+            }
+    )
+    @Parameter(name = "redirect", in = ParameterIn.QUERY, description = "Redirect Url for FE", required = true, schema = @Schema(type = "string"))
     @GetMapping("/github")
     public void githubAuthRedirect(HttpServletResponse response, @RequestParam("redirect") String redirect) {
         authService.redirectGithub(response, redirect);
     }
 
-    @ApiOperation(value = "Redirect to Github Login page.", notes = "Redirect to Github Login page to get an auth code.")
+    @Operation(summary = "Redirect to Github Login page.", description = "Redirect to Github Login page to get an auth code.")
     @PostMapping("/callback")
     public ResponseDto<OAuthDto.GithubTokenResponse> githubAuth(@RequestBody AuthRequestDto request) {
         OAuthDto.GithubTokenResponse response = authService.getAccessToken(request);

--- a/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/UserController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/user/controller/UserController.java
@@ -3,42 +3,49 @@ package com.initcloud.rocket23.user.controller;
 import com.initcloud.rocket23.common.dto.ResponseDto;
 import com.initcloud.rocket23.user.dto.UserDto;
 import com.initcloud.rocket23.user.service.UserService;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-@ApiOperation("User Info API")
+@Tag(name = "User Info API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rocket/user")
 public class UserController {
 
-	private final UserService userService;
+    private final UserService userService;
 
-	@ApiOperation(value = "User Profile", notes = "Show user's individual profile.")
-	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", paramType = "header", value = "Authorization Code", required = true, dataTypeClass = UserDto.Profile.class)})
-	@GetMapping()
-	public ResponseDto<UserDto.Profile> profileDetails() {
-		UserDto.Profile response = userService.getUserDetails();
+    @Operation(summary = "User Profile", description = "Show user's individual profile.")
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, description = "Authorization Code", required = true, schema = @Schema(implementation = UserDto.Profile.class))
+    @GetMapping()
+    public ResponseDto<UserDto.Profile> profileDetails() {
+        UserDto.Profile response = userService.getUserDetails();
 
-		return new ResponseDto<>(response);
-	}
+        return new ResponseDto<>(response);
+    }
 
-	// 내가 속한 팀 목록
-	@ApiOperation(value = "User's Team List", notes = "Show user's teams.")
-	@ApiImplicitParams({
-			@ApiImplicitParam(name = "Authorization", paramType = "header", value = "Authorization Code", required = true, dataTypeClass = List.class)})
-	@GetMapping("teams")
-	public ResponseDto<List<UserDto.MyTeam>> userTeams() {
-		List<UserDto.MyTeam> response = userService.getUserTeamList();
+    // 내가 속한 팀 목록
+    @Operation(summary = "User's Team List", description = "Show user's teams.")
+    @Parameter(
+            name = "Authorization",
+            in = ParameterIn.HEADER,
+            description = "Authorization Code",
+            required = true,
+            content = @Content(array = @ArraySchema(schema = @Schema(type = "string")))
+    )
+    @GetMapping("teams")
+    public ResponseDto<List<UserDto.MyTeam>> userTeams() {
+        List<UserDto.MyTeam> response = userService.getUserTeamList();
 
-		return new ResponseDto<>(response);
-	}
+        return new ResponseDto<>(response);
+    }
 }

--- a/scanhistory/src/main/resources/application.yaml
+++ b/scanhistory/src/main/resources/application.yaml
@@ -24,4 +24,18 @@ spring:
       pageable:
         default-page-size: 10
 
-
+springdoc:
+  swagger-ui:
+    path: /swagger-ui
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+  cache:
+    disabled: true
+  packages-to-exclude:
+  paths-to-exclude:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## Update
- [x] Hot Fix
- [ ] Release
- [ ] Develop
- [ ] Others

## Description
* Fix #85 

## Update Summary
각종 Controller에서 사용한 Swagger 어노테이션 변경

## New/Edited policies
Spring-fox implementation을 Spring-doc에서 지원하는 형태로 변경

## Resolved Issue
![image](https://github.com/money-driven-development/rocket23/assets/91025314/45f792d1-2865-4027-8d9d-ba892552c51f)
기존에 슬랙으로 여러번 문의했던 내용의 오류를 해결했습니다. Gradle의 버전을 맞추어 보아도, ant_patcher 등 여러가지 방법을 적용해보았지만 해결되지 않아 업그레이드가 중단된 여러 문제가 존재하는 spring fox에서 spring-doc으로 마이그레이션을 진행하여 제대로 동작하는 것을 확인하였습니다.

## Unresolved Issue
File 패키지나 Docker 패키지의 경우 추후 변경 예정

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [ ] 변경 내역에 대해 주석을 작성했습니다.
- [x] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.