### PR TITLE
Feature/#105 divide aws ncp policy set

### DIFF
--- a/file/src/main/resources/application.yaml
+++ b/file/src/main/resources/application.yaml
@@ -4,3 +4,7 @@ spring:
       max-file-size: 50MB
       max-request-size: 50MB
       location: ${UPLOAD_PATH:./uploads}
+  redis:
+    host: ${REDIS_DATASOURCE_URL:localhost}
+    port: ${REDIS_PORT:6379}
+    password: ${REDIS_PASSWORD:dev}

--- a/scanhistory/src/main/java/com/initcloud/rocket23/policy/controller/BasePolicySetController.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/policy/controller/BasePolicySetController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,11 +41,11 @@ public class BasePolicySetController {
                     )}
     )
     @Parameter(name = "teamCode", in = ParameterIn.PATH, description = "Team unique code", required = true, schema = @Schema(type = "string"))
-    @GetMapping("/{teamCode}/basePolicySets")
+    @PostMapping("/{teamCode}/basePolicySets")
     public ResponseDto<Page<Summary>> baseTeamPolicySet(
             @PathVariable String teamCode
     ) {
-        basePolicySetService.createBasePolicySet(teamCode);
+        basePolicySetService.createBasePolicySetList(teamCode);
         return new ResponseDto<>(null);
     }
 

--- a/scanhistory/src/main/java/com/initcloud/rocket23/policy/service/BasePolicySetService.java
+++ b/scanhistory/src/main/java/com/initcloud/rocket23/policy/service/BasePolicySetService.java
@@ -87,7 +87,19 @@ public class BasePolicySetService {
      * Base Policy 정책 셋 팀 추가
      */
     @Transactional
-    public void createBasePolicySet(final String teamCode) {
+    public void createBasePolicySetList(final String teamCode) {
+
+        createBasePolicySet(teamCode, "기본 제공되는 AWS(1) Base Policy Set 입니다.", "AWS1_Base_Policy_Set", "IC_AWS");
+        createBasePolicySet(teamCode, "기본 제공되는 AWS(2) Base Policy Set 입니다.", "AWS2_Base_Policy_Set", "IC2_AWS");
+        createBasePolicySet(teamCode, "기본 제공되는 AWS(3) Base Policy Set 입니다.", "AWS3_Base_Policy_Set", "IC3_AWS");
+        createBasePolicySet(teamCode, "기본 제공되는 NCP Base Policy Set 입니다.", "NCP_Base_Policy_Set", "NCP");
+    }
+
+    /**
+     * Base Policy 정책 셋 팀 추가
+     */
+    @Transactional
+    public void createBasePolicySet(final String teamCode, String description, String name, String csp) {
 
         // 1. 대상 팀의 Base Policy를 Team Policy로 등록
         Team team = basePolicyAllToTeamPolicy(teamCode);
@@ -97,8 +109,8 @@ public class BasePolicySetService {
 
         PolicySet basePolicySet = PolicySet.builder()
                 .team(team)
-                .description("기본 제공되는 Base Policy Set 입니다.")
-                .name("Base_Policy_Set")
+                .description(description)
+                .name(name)
                 .build();
 
         // 3. 정책 셋을 만들고
@@ -106,7 +118,9 @@ public class BasePolicySetService {
 
         // 4. 정책 셋의 정책 목록에 정책 추가
         List<PolicyPerPolicySet> policiesPerPolicySet = new ArrayList<>();
-        baseTeamPolicies.forEach(policy -> policiesPerPolicySet.add(new PolicyPerPolicySet(policySet, policy, true)));
+        baseTeamPolicies.stream()
+                .filter(policy -> policy.getPolicyName().contains(csp))
+                .forEach(policy -> policiesPerPolicySet.add(new PolicyPerPolicySet(policySet, policy, true)));
         policyPerPolicySetRepository.saveAll(policiesPerPolicySet);
     }
 


### PR DESCRIPTION
## Target Issue
- #105 

## Performance Period
2/2-2/6

## Summary
기존의 AWS 와 NCP가 통합되어 있던 Base Policy Set을 분리하고자 함.

## Detail
기존의 Base Policy 등록 로직에 필터를 걸어 IC_AWS, NCP 등으로 나누어 Base Policy Set 등록
